### PR TITLE
Issue #368: adjust Rowan bootstrap so that JadeServer classes are intalled before the Rowan-Services-Tests

### DIFF
--- a/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
+++ b/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
@@ -611,6 +611,13 @@ currentOrNil
   commit
 
   run
+  CypressBootstrapRowanBlock
+    value: 'UserGlobals'
+    value: #( 'Rowan-JadeServer').           "install JadeServer classes"
+%
+  commit
+
+  run
   CypressBootstrapRowanBlock 
     value: 'RowanKernel'
     value: #('Rowan-Tools-Extensions' 'Rowan-Deprecated' 'Rowan-Tests' 'Rowan-Services-Tests'	
@@ -641,13 +648,6 @@ currentOrNil
       'Rowan-Tools-Kernel' 
       'Rowan-GemStone-3215'
 	).		"Extension methods for GemStone kernel classes"
-%
-  commit
-
-  run
-  CypressBootstrapRowanBlock
-    value: 'UserGlobals'
-    value: #( 'Rowan-JadeServer').           "install JadeServer classes"
 %
   commit
 

--- a/rowan/src/Rowan-Services-Tests/JadeServerTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/JadeServerTest.class.st
@@ -15,7 +15,7 @@ JadeServerTest >> jadeServer [
 JadeServerTest >> test_jadeServerCanonicalLocation [
 	"We reuse the topaz session state slot. Safe because this is not a topaz session"
 	
-	self assert: ((System __sessionStateAt: 3) isKindOf: (UserGlobals at: #JadeServer64bit32)).
+	self assert: ((System __sessionStateAt: 3) isKindOf: JadeServer64bit32).
 	self assert: ((System __sessionStateAt: 3) class canUnderstand: #updateFromSton:)
 ]
 
@@ -32,11 +32,13 @@ JadeServerTest >> test_jadeServerExists [
 
 	See RsGsPlatform>>jadeServerClassNamed: for symbol list JadeServer*
 	lives in. Note that method will only lookup JadeServer & JadeServer64bit32"
-				
-	| jadeServerClass |
-	#(#JadeServer #JadeServer64bit #JadeServer64bit24 #JadeServer64bit3x #JadeServer64bit32) do:[:className |
-		jadeServerClass := UserGlobals at: className. 
-		self assert: jadeServerClass name = className asSymbol].
+
+	"if method compiles we're in like flint"
+	{JadeServer .
+			JadeServer64bit .
+				JadeServer64bit24 .
+					JadeServer64bit3x .
+						JadeServer64bit32}.
 ]
 
 { #category : 'tests' }
@@ -58,15 +60,15 @@ JadeServerTest >> test_jadeServerHierarchyValid [
 	subclasses :=  jadeServerClass subclasses asArray.
 	self assert: subclasses size equals: 1. 
 	self assert: subclasses first name = #JadeServer64bit.
-	jadeServerClass := UserGlobals at: subclasses first name. 
+	jadeServerClass := Rowan globalNamed: subclasses first name. 
 	subclasses :=  jadeServerClass subclasses asArray.
 	self assert: subclasses size equals: 1. 
 	self assert: subclasses asArray first name = #JadeServer64bit24.
-	jadeServerClass := UserGlobals at: subclasses first name. 
+	jadeServerClass :=  Rowan globalNamed: subclasses first name. 
 	subclasses :=  jadeServerClass subclasses asArray.
 	self assert: subclasses size equals: 1. 
 	self assert: subclasses asArray first name = #JadeServer64bit3x.
-	jadeServerClass := UserGlobals at: subclasses first name. 
+	jadeServerClass :=  Rowan globalNamed: subclasses first name. 
 	subclasses :=  jadeServerClass subclasses asArray.
 	self assert: subclasses size equals: 1. 
 	self assert: subclasses asArray first name = #JadeServer64bit32.
@@ -80,13 +82,13 @@ JadeServerTest >> test_rowanCanFindJadeServer [
 
 	self assert: (Rowan class canUnderstand: #jadeServerClassNamed:).
 	self assert: (RwGsPlatform canUnderstand: #jadeServerClassNamed:).
-	self assert: (Rowan jadeServerClassNamed: #JadeServer64bit32) equals: (UserGlobals at: #JadeServer64bit32)
+	self assert: (Rowan jadeServerClassNamed: #JadeServer64bit32) equals: JadeServer64bit32
 ]
 
 { #category : 'tests' }
 JadeServerTest >> test_serviceUsesCanonicalJadeServer [
 	
-	self assert: (RowanAnsweringService new jadeServer isKindOf: (UserGlobals at: #JadeServer64bit32)).
+	self assert: (RowanAnsweringService new jadeServer isKindOf: JadeServer64bit32).
 	self assert: RowanAnsweringService new jadeServer == (System __sessionStateAt: 3)
 ]
 
@@ -98,7 +100,7 @@ JadeServerTest >> test_updateFromSton [
 
 	| service stonString resultString services |
 
-	self assert: ((UserGlobals at: #JadeServer) canUnderstand: #updateFromSton:).
+	self assert: JadeServer canUnderstand: #updateFromSton:.
 	service := RowanQueryService new 
 				command: #implementorsOf:; 
 				commandArgs: (Array with: #test_updateFromSton).


### PR DESCRIPTION
As part of this work, I removed all of UserGlobals references in the JadeServer tests and replaced them with direct references to the class or with a lookup using the preferred `Rowan globalNamed:`. 

Here's the test result summary:
```
Rowan STON Cypress Tonel tests for GemStone '3.2.15'
548 run, 529 passed, 4 failed, 15 errors
  errors
	JadeServerTest>>#test_updateFromSton
	RowanClassServiceTest>>#testAddCategory
	RowanClassServiceTest>>#testClassComment
	RowanProjectServiceTest>>#test_addPackage
	RowanProjectServiceTest>>#test_updateAddsCommandResult
	RwBrowserToolApiTest>>#testMoveGlobalExtensionSessionMethods
	RwBrowserToolApiTest>>#testNewClassVersion_session_method_change_extension_method_source
	RwHybridBrowserToolTest>>#testHybridMoveMethodFromSessionMethodsIntoSessionMethods
	RwHybridBrowserToolTest>>#testHybridMoveMethodIntoSessionMethods
	RwRowanSample2Test>>#testNoMigration_gitolite
	STONLargeWriteReadTests>>#testUnicodeStrings
	STONReaderTests>>#testString
	STONWritePrettyPrinterReadTests>>#testUnicodeStrings
	STONWriteReadTests>>#testUnicodeStrings
	TonelCypressReaderTest>>#testLoadDefinitions
  failures
	JadeServerTest>>#test_jadeServerCanonicalLocation
	JadeServerTest>>#test_serviceUsesCanonicalJadeServer
	RwLoadingTest>>#testPoolDictionaryChanges
	RwSymbolDictionaryTest>>#testClassVersioningPatch
```