### PR TITLE
v1.1.2 release

### DIFF
--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
@@ -27,19 +27,13 @@ output push patch_issue_365.out
 										| theClass |
 										classHistory current name == className
 											ifTrue: [ 
-												GsFile gciLogServer: 'ClassHistory: ', classHistory asOop printString.
 												classHistory reverseDo: [:cls |
-GsFile gciLogServer: 'cls --> ', cls name printString, ' -- ', theClass printString.
 													(theClass isNil and: [ cls allSelectors includes: #updateFromSton: ])
-														ifTrue: [ theClass := cls.
-GsFile gciLogServer: '+' ]
-														ifFalse: [ GsFile gciLogServer: '-' ] ].
+														ifTrue: [ theClass := cls ] ].
 												theClass ifNil: [ self error: 'no class found for ', className, ' in class history' ].
 												UserGlobals at: className put: theClass.
 												theClass classHistory == classHistory 
-													ifFalse: [ 
-GsFile gciLogServer: '--> ',  theClass name printString, ' -- ', className printString, ' -- ', classHistory current name printString.
-self halt].
+													ifFalse: [ self error: 'class history mismatch for ', className ].
 												GsFile gciLogServer: '	Replaced ', className, ' (', theClass asOop printString, ')' ] ] ] ]
 					ifNil: [
 						GsFile gciLogServer: 'Needs Patching ...', className.

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
@@ -9,8 +9,30 @@ output push patch_issue_365.out
   login
 
 	run
+	"patch missing JadeServer classes - so they can be disowned and updated"
+	#(JadeServer64bit24
+		JadeServer64bit3x
+		JadeServer
+		JadeServer64bit32
+		JadeServer64bit )
+			do: [:className |
+				(UserGlobals at: className ifAbsent: [])
+					ifNil: [
+						GsFile gciLogServer: 'Needs Patching ...', className.
+						(UserGlobals at: #RwSymbolDictionaryRegistry)
+							classRegistry keys do: [:classHistory |
+								| theClass |
+								theClass := classHistory current.
+								theClass name == className
+									ifTrue: [ 
+										UserGlobals at: className put: theClass.
+										GsFile gciLogServer: '	Patched ', className ] ] ] ].
+%
+	commit
+
+	run
 	Rowan projectNames do: [:projectName |
-		GsFile gciLogServer: 'Disown projectName'.
+		GsFile gciLogServer: 'Disown ', projectName.
 		Rowan projectTools disown
 			disownProjectNamed: projectName ].
 %

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
@@ -4,12 +4,13 @@ output push patch_issue_365.out
   iferr 1 stk
   iferr 2 stack
   iferr 3 exit 1
+	display oops
 
   set u SystemUser p swordfish
   login
 
 	run
-	"patch missing JadeServer classes - so they can be disowned and updated"
+	"patch missing JadeServer classes or JadeServer classes that were overwritten by JadeiteAlpha - so they can be disowned and updated"
 	#(JadeServer64bit24
 		JadeServer64bit3x
 		JadeServer
@@ -17,12 +18,35 @@ output push patch_issue_365.out
 		JadeServer64bit )
 			do: [:className |
 				(UserGlobals at: className ifAbsent: [])
+					ifNotNil: [:aClass | 
+						(aClass allSelectors includes: #updateFromSton:)
+							ifFalse: [ 
+								GsFile gciLogServer: 'Needs Replacing ...', className, ' (', aClass asOop printString, ')'.
+								(UserGlobals at: #RwSymbolDictionaryRegistry)
+									classRegistry keys do: [:classHistory |
+										| theClass |
+										classHistory current name == className
+											ifTrue: [ 
+												GsFile gciLogServer: 'ClassHistory: ', classHistory asOop printString.
+												classHistory reverseDo: [:cls |
+GsFile gciLogServer: 'cls --> ', cls name printString, ' -- ', theClass printString.
+													(theClass isNil and: [ cls allSelectors includes: #updateFromSton: ])
+														ifTrue: [ theClass := cls.
+GsFile gciLogServer: '+' ]
+														ifFalse: [ GsFile gciLogServer: '-' ] ].
+												theClass ifNil: [ self error: 'no class found for ', className, ' in class history' ].
+												UserGlobals at: className put: theClass.
+												theClass classHistory == classHistory 
+													ifFalse: [ 
+GsFile gciLogServer: '--> ',  theClass name printString, ' -- ', className printString, ' -- ', classHistory current name printString.
+self halt].
+												GsFile gciLogServer: '	Replaced ', className, ' (', theClass asOop printString, ')' ] ] ] ]
 					ifNil: [
 						GsFile gciLogServer: 'Needs Patching ...', className.
 						(UserGlobals at: #RwSymbolDictionaryRegistry)
 							classRegistry keys do: [:classHistory |
 								| theClass |
-								theClass := classHistory current.
+								theClass := classHistory current. 
 								theClass name == className
 									ifTrue: [ 
 										UserGlobals at: className put: theClass.


### PR DESCRIPTION
Update the `platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz` with logic for patching dbs that have been corrupted by:
1. straight deletion of JadeServer classes from UserGlobals
2. override of JadeServer classes by logging in with JadeiteAlpha2.0.1