### PR TITLE
v1.2.2 release  (Jadeite-Oscar-3.0.45)

### DIFF
--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -25,6 +25,7 @@ set -e
 # 1.1.1 candidate 2 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate_2 v1.1.1-candidate_2 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.1 candidate 3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate_3 v1.1.1-candidate_3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.2.0 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.0 v1.2.0 Oscar-3.0.40 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.2.1 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.1 v1.2.1 Oscar-3.0.45 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"
@@ -124,8 +125,9 @@ validate_tag Rowan Rowan "$rowan_tag" $rowanDeploymentBranch
 
 # create Jadeite runtime directory
 jadeite_runtime_dirName="Jadeite_runtime_${jadeite_tag}"
-cp -r ~/ubs/runtime  "$jadeite_runtime_dirName"
-wget https://github.com/GemTalk/Jadeite/releases/download/"$jadeite_tag"/Jadeite.exe -P "$jadeite_runtime_dirName"
+wget https://github.com/GemTalk/Jadeite/releases/download/"$jadeite_tag"/runtime.zip
+unzip runtime.zip
+mv runtime "$jadeite_runtime_dirName"
 
 echo "" >> MANIFEST.TXT
 echo "------------------------------" >> MANIFEST.TXT

--- a/platforms/gemstone/topaz/3.2.15/patches/delete_methods_and_classes_for_issue_365.gs
+++ b/platforms/gemstone/topaz/3.2.15/patches/delete_methods_and_classes_for_issue_365.gs
@@ -1,0 +1,65 @@
+! commented out symbols are needed by either the Rowan audit tool or the audit blocks
+  run
+	{
+		{ Behavior . 
+			{
+					#persistentSuperclassForEnv: . #persistentSuperclassForEnv:put: . #moveMethod:toCategory:environmentId: . 
+"
+					#rowanPackageName . #rowanProjectName . 
+"
+					#rwCompileMethod:category: . #rwCompileMethod:category:packageName: .
+					#rwMoveMethod:toCategory: . #rwRemoveSelector: . #_rowanCopyMethodsAndVariablesFrom:dictionaries: .
+					#_rwInstVar:constrainTo: . #_rwNewConstraint:atOffset: . #_rwNewInheritedConstraint:atOffset: .
+			} }.
+		{ Class . 
+			{
+					#byteSubclass:classVars:classInstVars:poolDictionaries:inDictionary:newVersionOf:description:options: .
+					#_equivalentSubclass:superCls:name:newOpts:newFormat:newInstVars:newClassInstVars:newPools:newClassVars:inDict:constraints:isKernel: .
+					#_subclass:instVarNames:format:constraints:classVars:classInstVars:poolDictionaries:inDictionary:inClassHistory:description:options: .
+					#stonName . #_rwSortedConstraints . #_rwOptionsForDefinition . #_rwOptionsArray . #_rwDefinitionOfConstraints . #rwComment: .  } }.
+"
+		{ ExecBlock . 
+			{
+					#cull: . #cull:cull: . #cull:cull:cull: . #cull:cull:cull:cull:
+			} }.
+"
+		{ GsFile class . 
+			{
+					#_stat:isLstat:	.		} }.
+		{ GsFile . 
+			{
+					#<<	.		} }.
+		{ GsPackagePolicy class. 
+			{
+					#currentOrNil .	
+		} }.
+		{ ByteArray . 
+			{
+					#byteArrayMap	.	#stonContainSubObjects . #readHexFrom: . #stonOn: . 	} }.
+		{ GsNMethod . 
+			{
+					#rowanPackageName . #rowanProjectName	.		} }.
+	} do: [:ar |
+		| beh |
+		beh := ar at: 1.
+		(ar at: 2)
+			do: [:selector | 
+				beh removeSelector: selector ] ].
+	System commit.	
+%
+
+	run
+	#(JadeServer64bit24
+		JadeServer64bit3x
+		JadeServer
+		JadeServer64bit32
+		JadeServer64bit )
+			do: [:className | UserGlobals removeKey: className ].
+	System commit.
+%
+
+	run
+	RowanClassServiceTest removeSelector: #createClassNamed:.
+	RowanProjectServiceTest removeSelector: #existingProjectNamed:.
+	System commit.
+%

--- a/platforms/gemstone/topaz/3.2.15/patches/new_audit_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/new_audit_issue_365.tpz
@@ -1,0 +1,29 @@
+output pushnew audit_issue_365.out
+
+  iferr 1 stk
+  iferr 2 stack
+#  iferr 3 exit 1
+
+  set u SystemUser p swordfish
+  login
+
+	run
+	| res audit |
+	GsFile gciLogServer: '--STARTING ROWAN AUDIT'.
+	res := KeyValueDictionary new.
+
+	Rowan projectNames do: [:projectName |
+		GsFile gciLogServer: '---Auditing project: ', projectName printString.
+		audit := Rowan projectTools audit auditForProjectNamed: projectName.
+		res at: projectName put: audit.
+		GsFile gciLogServer: '	-- audit finished ' ].
+	UserGlobals at: #ROWAN_AUDIT_issue_365_results put: res.
+	GsFile gciLogServer: '--ENDING ROWAN AUDIT'.
+	true
+%
+  commit
+
+  logout
+	errorCount
+
+	output pop

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
@@ -4,13 +4,53 @@ output push patch_issue_365.out
   iferr 1 stk
   iferr 2 stack
   iferr 3 exit 1
+	display oops
 
   set u SystemUser p swordfish
   login
 
 	run
+	"patch missing JadeServer classes or JadeServer classes that were overwritten by JadeiteAlpha - so they can be disowned and updated"
+	#(JadeServer64bit24
+		JadeServer64bit3x
+		JadeServer
+		JadeServer64bit32
+		JadeServer64bit )
+			do: [:className |
+				(UserGlobals at: className ifAbsent: [])
+					ifNotNil: [:aClass | 
+						(aClass allSelectors includes: #updateFromSton:)
+							ifFalse: [ 
+								GsFile gciLogServer: 'Needs Replacing ...', className, ' (', aClass asOop printString, ')'.
+								(UserGlobals at: #RwSymbolDictionaryRegistry)
+									classRegistry keys do: [:classHistory |
+										| theClass |
+										classHistory current name == className
+											ifTrue: [ 
+												classHistory reverseDo: [:cls |
+													(theClass isNil and: [ cls allSelectors includes: #updateFromSton: ])
+														ifTrue: [ theClass := cls ] ].
+												theClass ifNil: [ self error: 'no class found for ', className, ' in class history' ].
+												UserGlobals at: className put: theClass.
+												theClass classHistory == classHistory 
+													ifFalse: [ self error: 'class history mismatch for ', className ].
+												GsFile gciLogServer: '	Replaced ', className, ' (', theClass asOop printString, ')' ] ] ] ]
+					ifNil: [
+						GsFile gciLogServer: 'Needs Patching ...', className.
+						(UserGlobals at: #RwSymbolDictionaryRegistry)
+							classRegistry keys do: [:classHistory |
+								| theClass |
+								theClass := classHistory current. 
+								theClass name == className
+									ifTrue: [ 
+										UserGlobals at: className put: theClass.
+										GsFile gciLogServer: '	Patched ', className ] ] ] ].
+%
+	commit
+
+	run
 	Rowan projectNames do: [:projectName |
-		GsFile gciLogServer: 'Disown projectName'.
+		GsFile gciLogServer: 'Disown ', projectName.
 		Rowan projectTools disown
 			disownProjectNamed: projectName ].
 %

--- a/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
+++ b/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
@@ -755,7 +755,9 @@ currentOrNil
 		do: [:projectDefinition |
 			| audit projectName |
 			projectName := projectDefinition name.
+			GsFile gciLogServer: '---Auditing project: ', projectName printString.
 			audit := Rowan projectTools audit auditForProjectNamed: projectName.
+			GsFile gciLogServer: '	-- audit finished '. 
 			audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ]
 	
 %

--- a/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
+++ b/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
@@ -750,20 +750,14 @@ currentOrNil
 		"mark projects and packages not dirty"
 		loadedProject markNotDirty.
 		loadedProject loadedPackages valuesDo: [:loadedPackage | loadedPackage markNotDirty ] ].
-	
 
-  true
-    ifTrue: [
-      | incorrectlyPackaged |
-      "quick and dirty validation that Rowan loaded with Rowan is correct"
-      incorrectlyPackaged := (ClassOrganizer new classes 
-	select: [:cl | 
-		(cl name asString beginsWith: 'Rw') 
-			or: [cl name asString beginsWith: 'Rowan' ]])
-	select: [:cl | 
-		(Rowan image loadedClassNamed: cl name asString ifAbsent: [])
-			handle ~~ cl ].
-      incorrectlyPackaged isEmpty ifFalse: [ self error: 'Rowan is not correctly packaged' ] ].
+	projectSetDefinition projects
+		do: [:projectDefinition |
+			| audit projectName |
+			projectName := projectDefinition name.
+			audit := Rowan projectTools audit auditForProjectNamed: projectName.
+			audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ]
+	
 %
   commit
 

--- a/platforms/gemstone/topaz/rowanTestSuite.gs
+++ b/platforms/gemstone/topaz/rowanTestSuite.gs
@@ -4,11 +4,21 @@ run
 	[
 		Deprecated doErrorOnDeprecated.
 		projectNames := #( 'Rowan' 'STON' 'Cypress' 'Tonel' ).
+		"audit before load"
 		projectNames do: [:projectName |
-			"load test groups ... include deprecated packages for now"
+			| audit |
+			audit := Rowan projectTools audit auditForProjectNamed: projectName.
+			audit isEmpty ifFalse: [ self error: 'Pre load Rowan audit failed for project ', projectName printString ] ].
+		projectNames do: [:projectName |
+			"make sure test group is loaded ... include deprecated packages for now"
 			Rowan projectTools load
 				loadProjectNamed: projectName
 				withGroupNames: #('tests' 'deprecated' 'jadeServer') ].
+		"audit after load"
+		projectNames do: [:projectName |
+			| audit |
+			audit := Rowan projectTools audit auditForProjectNamed: projectName.
+			audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ].
 
 		suite := Rowan projectTools test testSuiteForProjectsNamed: projectNames.
 		res := suite run.

--- a/rowan/src/Rowan-Core/RwLoadedClass.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedClass.class.st
@@ -80,17 +80,29 @@ RwLoadedClass >> loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassM
 	loadedInstanceMethods
 		valuesDo: [ :loadedMethod | 
 			loadedInstanceMethodBlock
-				cull: self loadedProject
+				cull:  self loadedProject
 				cull: self loadedPackage
-				cull: self
-				cull: loadedMethod ].
+				cull: self 
+				cull: loadedMethod
+				
+	].
 	loadedClassMethods
 		valuesDo: [ :loadedMethod | 
 			loadedClassMethodBlock
 				cull: self loadedProject
 				cull: self loadedPackage
-				cull: self
-				cull: loadedMethod ]
+				cull: self 
+				cull: loadedMethod
+	]
+]
+
+{ #category : 'testing' }
+RwLoadedClass >> loadedMethodAt: aSelector isMeta: isMeta [
+
+	^ isMeta
+		ifTrue: [ loadedClassMethods at: aSelector ifAbsent: [nil]]
+		ifFalse: [ loadedInstanceMethods at: aSelector ifAbsent: [nil] ]
+
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Core/RwLoadedClassExtension.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedClassExtension.class.st
@@ -83,17 +83,30 @@ RwLoadedClassExtension >> loadedInstanceMethodsDo: loadedInstanceMethodBlock loa
 	loadedInstanceMethods
 		valuesDo: [ :loadedMethod | 
 			loadedInstanceMethodBlock
-				cull: self loadedProject
+				cull: self loadedProject 
 				cull: self loadedPackage
-				cull: self
-				cull: loadedMethod ].
+				cull: self 
+				cull: loadedMethod
+				
+	].
 	loadedClassMethods
 		valuesDo: [ :loadedMethod | 
 			loadedClassMethodBlock
 				cull: self loadedProject
 				cull: self loadedPackage
-				cull: self
-				cull: loadedMethod ]
+				cull: self 
+				cull: loadedMethod 
+				
+	].
+
+]
+
+{ #category : 'private' }
+RwLoadedClassExtension >> loadedMethodAt: aSelector isMeta: isMeta [
+
+	^ isMeta
+		ifTrue: [ loadedClassMethods at: aSelector ifAbsent: [nil]]
+		ifFalse: [ loadedInstanceMethods at: aSelector ifAbsent: [nil] ]
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Core/RwLoadedPackage.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedPackage.class.st
@@ -45,6 +45,12 @@ RwLoadedPackage >> asDefinition [
 		classExtensions: self classExtensionDefinitions
 ]
 
+{ #category : 'other' }
+RwLoadedPackage >> asExtensionName [
+
+	^'*', self name asLowercase
+]
+
 { #category : 'private' }
 RwLoadedPackage >> classDefinitions [
 	"Create definitions from all of the classes I define, and answer the collection of them"
@@ -85,7 +91,7 @@ RwLoadedPackage >> key [
 ]
 
 { #category : 'enumeration' }
-RwLoadedPackage >> loadedClassedDo: loadedClassBlock loadedClassExtenstionsDo: loadedClassExtensionBlock loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassMethodsDo: loadedClassMethodBlock [
+RwLoadedPackage >> loadedClassedDo: loadedClassBlock loadedClassExtensionsDo: loadedClassExtensionBlock loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassMethodsDo: loadedClassMethodBlock [
 
 	loadedClasses
 		valuesDo: [ :loadedClass | 
@@ -102,11 +108,54 @@ RwLoadedPackage >> loadedClassedDo: loadedClassBlock loadedClassExtenstionsDo: l
 			loadedClassExtension
 				loadedInstanceMethodsDo: loadedInstanceMethodBlock
 				loadedClassMethodsDo: loadedClassMethodBlock ]
+
 ]
 
 { #category : 'accessing' }
 RwLoadedPackage >> loadedClasses [
 	^loadedClasses
+
+]
+
+{ #category : 'enumeration' }
+RwLoadedPackage >> loadedClassesDo: loadedClassBlock loadedClassExtensionsDo: loadedClassExtensionBlock [ 
+
+	loadedClasses
+		valuesDo: [ :loadedClass | 
+			loadedClassBlock 
+				cull: loadedClass
+				cull: self loadedProject 
+				cull: self].
+	loadedClassExtensions
+		valuesDo: [ :loadedClassExtension | 
+			loadedClassExtensionBlock
+				cull: loadedClassExtension
+				cull: self loadedProject
+				cull: self ]
+
+]
+
+{ #category : 'enumeration' }
+RwLoadedPackage >> loadedClassesDo: loadedClassBlock loadedClassExtensionsDo: loadedClassExtensionBlock loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassMethodsDo: loadedClassMethodBlock [
+
+	loadedClasses
+		valuesDo: [ :loadedClass | 
+			loadedClassBlock 
+				cull: loadedClass
+				cull: self loadedProject 
+				cull: self. 
+			loadedClass
+				loadedInstanceMethodsDo: loadedInstanceMethodBlock
+				loadedClassMethodsDo: loadedClassMethodBlock ].
+	loadedClassExtensions
+		valuesDo: [ :loadedClassExtension | 
+			loadedClassExtensionBlock
+				cull: loadedClassExtension
+				cull: self loadedProject
+				cull: self.
+			loadedClassExtension
+				loadedInstanceMethodsDo: loadedInstanceMethodBlock
+				loadedClassMethodsDo: loadedClassMethodBlock ]
 
 ]
 

--- a/rowan/src/Rowan-Core/RwLoadedProject.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedProject.class.st
@@ -99,14 +99,14 @@ RwLoadedProject >> loadedPackages: anObject [
 ]
 
 { #category : 'enumeration' }
-RwLoadedProject >> loadedPackagesDo: loadedPackageBlock loadedClassedDo: loadedClassBlock loadedClassExtenstionsDo: loadedClassExtensionBlock loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassMethodsDo: loadedClassMethodBlock [
+RwLoadedProject >> loadedPackagesDo: loadedPackageBlock loadedClassedDo: loadedClassBlock loadedClassExtensionsDo: loadedClassExtensionBlock loadedInstanceMethodsDo: loadedInstanceMethodBlock loadedClassMethodsDo: loadedClassMethodBlock [
 
 	loadedPackages
 		valuesDo: [ :loadedPackage | 
 			loadedPackageBlock cull: self cull: loadedPackage.
 			loadedPackage
 				loadedClassedDo: loadedClassBlock
-				loadedClassExtenstionsDo: loadedClassExtensionBlock
+				loadedClassExtensionsDo: loadedClassExtensionBlock
 				loadedInstanceMethodsDo: loadedInstanceMethodBlock
 				loadedClassMethodsDo: loadedClassMethodBlock ]
 ]

--- a/rowan/src/Rowan-Core/RwLoadedThing.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedThing.class.st
@@ -132,6 +132,12 @@ RwLoadedThing >> propertyAt: propertyName [
 ]
 
 { #category : 'accessing' }
+RwLoadedThing >> propertyAt: propertyName ifAbsent: aBlock [
+
+	^properties at: propertyName ifAbsent: aBlock
+]
+
+{ #category : 'accessing' }
 RwLoadedThing >> propertyAt: propertyName put: aValue [
 	"Value should be a string"
 

--- a/rowan/src/Rowan-Core/RwMethodModificationForNewClassVersion.class.st
+++ b/rowan/src/Rowan-Core/RwMethodModificationForNewClassVersion.class.st
@@ -16,7 +16,22 @@ RwMethodModificationForNewClassVersion >> addModificationToPatchSetForNewClassVe
 	self isDeletion
 		ifTrue: [ 
 			"method deletions on a new class version can be ignored: https://github.com/dalehenrich/Rowan/issues/353"
-			^ self ].
+			"method deletions on a new class version needs to have the loaded things taken core of: https://github.com/dalehenrich/Rowan/issues/393"
+
+			"treat like a deletion, since this ends up being a deletion of a method from the new class version"
+			self isMeta
+				ifTrue: [ 
+					aPatchSet
+						addDeletedClassMethod: self before
+						inClass: self classDefinition
+						inPackage: aPackage
+						inProject: aProjectDefinition ]
+				ifFalse: [ 
+					aPatchSet
+						addDeletedInstanceMethod: self before
+						inClass: self classDefinition
+						inPackage: aPackage
+						inProject: aProjectDefinition ] ].
 	(self isAddition or: [ self isModification ])
 		ifTrue: [ 
 			"treat like an addition, since this ends up being an addition of a method to the new class version"

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1187,7 +1187,6 @@ RwGsPatchSet_254 >> removeDeletedMethods [
 			methodDeletionPatch
 				deleteNewVersionMethodNewClasses: createdClasses
 				andExistingClasses: tempSymbols  ]
-
 ]
 
 { #category : 'private - applying' }

--- a/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : 'Rowan-Services-Tests'
 }
 
+{ #category : 'patch' }
+RowanClassServiceTest >> createClassNamed: className [
+
+]
+
 { #category : 'support' }
 RowanClassServiceTest >> setUp [
 

--- a/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
@@ -5,6 +5,15 @@ Class {
 }
 
 { #category : 'support' }
+RowanProjectServiceTest >> existingProjectNamed: projectName [
+
+	| projectService |
+	projectService := RowanProjectService newNamed: projectName. 
+	self assert: (Rowan image loadedProjectNamed: projectName) name equals: projectName.
+	^projectService
+]
+
+{ #category : 'support' }
 RowanProjectServiceTest >> projectServiceNamed: projectName [
 
 	| projectService |

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -664,7 +664,7 @@ RwBrowserToolApiTest >> testDeleteComplicatedPackage [
 										assert: false
 										description:
 											'no classes expected in ' , (packageNames2 at: 2) printString ] ] ]
-				loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+				loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 					self assert: theLoadedProject == loadedProject.
 					self assert: theLoadedPackage == loadedPackage.
 					self
@@ -811,7 +811,7 @@ RwBrowserToolApiTest >> testDeleteComplicatedPackage [
 										assert: false
 										description:
 											'no classes expected in ' , (packageNames2 at: 2) printString ] ] ]
-				loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+				loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 					self assert: theLoadedProject == loadedProject.
 					self assert: theLoadedPackage == loadedPackage.
 					self
@@ -893,7 +893,6 @@ RwBrowserToolApiTest >> testDeleteComplicatedPackage [
 	testProjectDefinition := browserTool projectNamed: projectName1.
 	testPackageNames := testProjectDefinition packageNames.
 	self assert: testPackageNames = {packageName2}
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwHybridBrowserToolTest.class.st
@@ -921,7 +921,7 @@ RwHybridBrowserToolTest >> testHybridComplicatedProjectLoad [
 											'Unexpected loaded class ' , loadedClass name printString , ' in '
 												, packageName2 ] ] ]
 				ifFalse: [ self assert: false description: 'No class expected in ' , packageName2 ] ]
-		loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+		loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 			self assert: theLoadedProject == loadedProject.
 			self assert: theLoadedPackage == loadedPackage.
 			self
@@ -1025,7 +1025,7 @@ RwHybridBrowserToolTest >> testHybridComplicatedProjectLoad [
 											'Unexpected loaded class ' , loadedClass name printString , ' in '
 												, packageName2 ] ] ]
 				ifFalse: [ self assert: false description: 'No class expected in ' , packageName2 ] ]
-		loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+		loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 			self assert: theLoadedProject == loadedProject.
 			self assert: theLoadedPackage == loadedPackage.
 			self
@@ -1098,7 +1098,6 @@ RwHybridBrowserToolTest >> testHybridComplicatedProjectLoad [
 	self should: [ normalInstance2 biff ] raise: MessageNotUnderstood.
 
 	writtenStateValidationBlock value	"verify that original state is restored"
-
 ]
 
 { #category : 'tests' }
@@ -1186,7 +1185,7 @@ RwHybridBrowserToolTest >> testHybridDeletePackage [
 					loadedPackage name = packageName2
 						ifTrue: [ self assert: loadedClass name = className2 ]
 						ifFalse: [ self assert: false description: 'unexpected package ' , loadedPackage name ] ] ]
-		loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+		loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 			self assert: false description: 'no class extensions expected in package '.
 			loadedPackage name ]
 		loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClassOrClassExtension :loadedMethod | 
@@ -2633,7 +2632,7 @@ RwHybridBrowserToolTest >> testHybridProjectLoad [
 					self assert: loadedClass name = className.
 					self assert: (loadedClass propertyAt: 'instvars') isEmpty ]
 				ifFalse: [ self assert: false description: 'No class expected in ' , packageName2 ] ]
-		loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+		loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 			self assert: theLoadedProject == loadedProject.
 			self assert: theLoadedPackage == loadedPackage.
 			self
@@ -2723,7 +2722,7 @@ RwHybridBrowserToolTest >> testHybridProjectLoad [
 					self assert: loadedClass name = className.
 					self assert: (loadedClass propertyAt: 'instvars') = #('ivar1') ]
 				ifFalse: [ self assert: false description: 'No class expected in ' , packageName2 ] ]
-		loadedClassExtenstionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
+		loadedClassExtensionsDo: [ :loadedProject :loadedPackage :loadedClassExtension | 
 			self assert: theLoadedProject == loadedProject.
 			self assert: theLoadedPackage == loadedPackage.
 			self
@@ -2772,7 +2771,6 @@ RwHybridBrowserToolTest >> testHybridProjectLoad [
 	self should: [ normalClass baz = 'baz' ] raise: MessageNotUnderstood.
 
 	writtenStateValidationBlock value	"verify that original state is restored"
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
@@ -1,14 +1,11 @@
+"
+testing audit api
+"
 Class {
 	#name : 'RwProjectAuditToolTest',
 	#superclass : 'RwBrowserToolTest',
 	#category : 'Rowan-Tests'
 }
-
-{ #category : 'other' }
-RwProjectAuditToolTest class >> comment [
-
-	^'testing audit api'
-]
 
 { #category : 'tests' }
 RwProjectAuditToolTest >> testClassBadExtension [

--- a/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
@@ -1,0 +1,222 @@
+Class {
+	#name : 'RwProjectAuditToolTest',
+	#superclass : 'RwBrowserToolTest',
+	#category : 'Rowan-Tests'
+}
+
+{ #category : 'other' }
+RwProjectAuditToolTest class >> comment [
+
+	^'testing audit api'
+]
+
+{ #category : 'tests' }
+RwProjectAuditToolTest >> testClassBadExtension [
+
+| packageTools projectName packageNames className packageName1 packageName2 theClass loadedClass loadedClassExtension fooMethod x y|
+	packageTools := Rowan packageTools.
+	projectName := 'AuditProject'.
+	packageName1 := 'Audit-Core'.
+	packageName2 := 'Audit-Extensions'.
+	packageNames := {packageName1 . packageName2}.
+	className := 'AuditClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment: 'project for testing audit api'.
+
+	theClass := Object
+		rwSubclass: className
+		instVarNames: #(bar)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+	self assert: theClass rowanPackageName = packageName1.
+
+   theClass rwCompileMethod: 'bar ^bar'
+	     category: 'Accessing' "'*'  packageName1 asLowercase".
+
+	fooMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: '*' , packageName2 asLowercase.
+
+	fooMethod := theClass
+		compileMethod: 'foo ^2'
+		dictionaries:  #() 
+		category: '*' , packageName1 asLowercase.
+
+x := RwClsAuditTool new auditLoadedClass: (loadedClass := Rowan image loadedClassForClass: theClass ifAbsent: [nil]).
+y := RwClsExtensionAuditTool new auditLoadedClassExtenstion: (loadedClassExtension := (Rowan image loadedClassExtensionsForClass: theClass) _at: 1).
+
+	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 2.
+	self assert: ( y := (x at: packageName1) at: className) size = 1;
+			assert: (y at: '*', packageName1 asLowercase) notNil;
+		assert: (y := (x at: packageName2) at: className) size = 1;
+		assert: (y at: '*', packageName2 asLowercase) notNil
+
+]
+
+{ #category : 'tests' }
+RwProjectAuditToolTest >> testClassExtension [
+
+| packageTools projectName packageNames className packageName1 packageName2 theClass loadedClass loadedClassExtension fooMethod x y|
+	packageTools := Rowan packageTools.
+	projectName := 'AuditProject'.
+	packageName1 := 'Audit-Core'.
+	packageName2 := 'Audit-Extensions'.
+	packageNames := {packageName1 . packageName2}.
+	className := 'AuditClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment: 'project for testing audit api'.
+
+	theClass := Object
+		rwSubclass: className
+		instVarNames: #(bar)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+	self assert: theClass rowanPackageName = packageName1.
+
+   theClass rwCompileMethod: 'bar ^bar'
+	     category: 'Accessing' "'*'  packageName1 asLowercase".
+
+	fooMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: '*' , packageName2 asLowercase.
+
+	fooMethod := theClass
+		compileMethod: 'bar: aBar bar := aBar'
+		dictionaries:  #() 
+		category: '*' , packageName2 asLowercase.
+
+
+"	((Rowan image loadedPackageNamed: 'Audit-Core') loadedClassForClass: (Rowan globalsAt: className asSymbol) value 
+		ifAbsent: [nil error: 'expected a loaded class']) 
+			loadedInstanceMethodsDo: [:anLMethod | (anLMethod name isEquivalent: 'bar') ifTrue: [self error: 'bar was compiled without Rowan']] 
+			loadedClassMethodsDo: [:cMethod | ].
+"
+x := RwClsAuditTool new auditLoadedClass: (loadedClass := Rowan image loadedClassForClass: theClass ifAbsent: [nil]).
+y := RwClsExtensionAuditTool new auditLoadedClassExtenstion: (loadedClassExtension := (Rowan image loadedClassExtensionsForClass: theClass) _at: 1).
+
+	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 1.
+	self assert: ((x at: packageName2) at: className) size = 1
+]
+
+{ #category : 'tests' }
+RwProjectAuditToolTest >> testClassVars [
+	| projectName packageNames className packageName classDefinition browserTool testClass testClassB testSymDict x |
+	projectName := 'AuditProject'.
+	packageName := 'Audit-Core'.
+	packageNames := {packageName}.
+    className := 'ClassWithVars'.
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName
+		comment: 'project for testing project browser api'.
+
+	classDefinition := RwClassDefinition
+		newForClassNamed: className
+		super: 'Object'
+		instvars: #('ivar1')
+		classinstvars: #('civar1')
+		classvars: #('Cvar1')
+		category: 'Simple Things'
+		comment: 'I am a Simple class with various vars'
+		pools: #()
+		type: 'normal'.
+
+	browserTool := Rowan projectTools browser.
+	browserTool createClass: classDefinition inPackageNamed: packageName.
+
+	testClass := Rowan globalNamed: className.
+	self assert: testClass notNil.
+
+	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') isEmpty.
+	
+	DateTime subclass: className
+	instVarNames: #( )
+	classVars: #( )
+	classInstVars: #()
+	poolDictionaries: #()
+	inDictionary: (System myUserProfile resolveSymbol: self _symbolDictionaryName) value
+	newVersionOf: testClass
+	description: 'Non rowan class'
+	options: #().
+
+	testClassB := Rowan globalNamed: className.
+	self deny: testClassB == testClass.
+	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 1.
+	self assert: ((x at: packageName) at: className) size = 4 description: 'expected 4 failures superclass instvars classvars and comment'
+]
+
+{ #category : 'tests' }
+RwProjectAuditToolTest >> testMissingMethods [
+
+| packageTools projectName packageNames className packageName theClass fooMethod x|
+	packageTools := Rowan packageTools.
+	projectName := 'AuditProject'.
+	packageName := 'Audit-Core'.
+	packageNames := {packageName}.
+	className := 'AuditClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment: 'project for testing audit api'.
+
+	theClass := Object
+		rwSubclass: className
+		instVarNames: #(bar)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName
+		options: #().
+	self assert: theClass rowanPackageName = packageName.
+
+	fooMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: "'*' , "packageName asLowercase.
+
+
+	theClass compileMissingAccessingMethods. "this should add: #bar #bar:"
+
+
+	((Rowan image loadedPackageNamed: 'Audit-Core') loadedClassForClass: (GsSession currentSession resolveSymbol: className asSymbol) value ifAbsent: [nil error: 'expected a class']) 
+			loadedInstanceMethodsDo: [:anLMethod | (anLMethod name isEquivalent: 'bar') ifTrue: [self error: 'bar was compiled without Rowan']] 
+			loadedClassMethodsDo: [:cMethod | "do nothing"].
+
+	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 1.
+	self assert: ((x at: packageName) at: className) size = 2
+		
+
+
+"	self _addOrUpdateMethod:  'foo ^''bar''' forBehavior: theClass inPackage: packageName inProjectNamed: projectName.
+
+	self _writeProjectNamed: projectName.
+
+	self _addOrUpdateMethod:  'foo ^''bar''' forBehavior: theClass class inPackage: packageName inProjectNamed: projectName.
+
+	self _writeProjectNamed: projectName.
+
+	self _removeSelector: #foo fromBehavior: theClass inProjectNamed: projectName.
+
+	self _writeProjectNamed: projectName.
+
+	self _removeSelector: #foo fromBehavior: theClass class inProjectNamed: projectName.
+
+	self _writeProjectNamed: projectName.
+"
+]

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -7708,10 +7708,112 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 ]
 
 { #category : 'tests-issue 393' }
+RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_extension_method_deletion_A [
+
+	"new test case:superclass has new class version ... the subclass has an extension method removed --- simplest case"
+	"https://github.com/dalehenrich/Rowan/issues/393"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 oldClass1 oldClass2 oldClass3 newClass1 audit classExtensionDefinition |
+
+	projectName := 'Issue326'.
+	packageName1 := 'Issue326-Core'.
+	packageName2 := 'Issue326-Extension'.
+	className1 := 'Issue326Class1'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: 'SuperMan'
+			super: 'Object'
+			instvars: #(ivar0)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classExtensionDefinition := RwClassExtensionDefinition newForClassNamed: className1.
+	classExtensionDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method1'
+					protocol: '*', packageName2 asLowercase
+					source: 'method1 ^1').
+
+	packageDefinition 
+		addClassExtension: classExtensionDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+
+"new class version of SuperMan and remove extension method"
+	projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	classDefinition := (projectDefinition packageNamed: packageName1) classDefinitions at: className1.
+
+	classDefinition := (projectDefinition packageNamed: packageName1) classDefinitions at: 'SuperMan'.
+	classDefinition instVarNames: #().
+
+	classExtensionDefinition := (projectDefinition packageNamed: packageName2) classExtensions at:className1.
+	classExtensionDefinition
+		removeInstanceMethod: #method1;
+		yourself.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+]
+
+{ #category : 'tests-issue 393' }
 RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_E [
 
 	"new test case:superclass has new class version ... each subclass has methods removed"
-	"https://github.com/dalehenrich/Rowan/issues/353"
+	"https://github.com/dalehenrich/Rowan/issues/393"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
@@ -7844,7 +7946,7 @@ RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_me
 RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_F [
 
 	"new test case:superclass has new class version ... each subclass has SOME methods removed"
-	"https://github.com/dalehenrich/Rowan/issues/353"
+	"https://github.com/dalehenrich/Rowan/issues/393"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
 		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
@@ -7969,6 +8071,97 @@ RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_me
 
 "validate"
 	self assert: ((Rowan image loadedClassNamed: className1) loadedInstanceMethods values select: [:loadedMethod | loadedMethod selector == #method4 ]) isEmpty
+]
+
+{ #category : 'tests-issue 393' }
+RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_G [
+
+	"new test case:superclass has new class version ... the subclass has a method removed --- simplest case"
+	"https://github.com/dalehenrich/Rowan/issues/393"
+
+	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 oldClass1 oldClass2 oldClass3 newClass1 audit |
+
+	projectName := 'Issue326'.
+	packageName := 'Issue326-Core'.
+	className1 := 'Issue326Class1'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: 'SuperMan'
+			super: 'Object'
+			instvars: #(ivar0)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method1'
+					protocol: 'accessing'
+					source: 'method1 ^1').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+
+"new class version of SuperMan and remove method"
+	projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className1.
+	classDefinition
+		removeInstanceMethod: #method1;
+		yourself.
+
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: 'SuperMan'.
+	classDefinition instVarNames: #().
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 40' }

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -7566,6 +7566,393 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 ]
 
+{ #category : 'tests-issue 353' }
+RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_method_deletion_D [
+
+	"new test case: both superclass and subclass have new class versions and method removed from each sublclass"
+	"https://github.com/dalehenrich/Rowan/issues/353"
+
+	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue326'.
+	packageName := 'Issue326-Core'.
+	className1 := 'Issue326Class1'.
+	className2 := 'Issue326Class2'.
+	className3 := 'Issue326Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: 'SuperMan'
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'SuperMan'
+			instvars: #(ivar4 ivar6)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method4'
+					protocol: 'accessing'
+					source: 'method4 ^3').
+	classDefinition
+		addClassMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method5'
+					protocol: 'accessing'
+					source: 'method5 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: 'SuperMan'
+			instvars: #(ivar1 ivar5 ivar3)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method3'
+					protocol: 'accessing'
+					source: 'method3 ^3').
+	classDefinition
+		addClassMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method2'
+					protocol: 'accessing'
+					source: 'method2 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+
+"new class version of SuperMan and remove methods"
+	projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className1.
+	classDefinition instVarNames: #(ivar4).
+	classDefinition
+		removeInstanceMethod: #method4;
+		removeClassMethod: #method5;
+		yourself.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className2.
+	classDefinition instVarNames: #(ivar1 ivar5).
+	classDefinition
+		removeInstanceMethod: #method3;
+		removeClassMethod: #method2;
+		yourself.
+
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: 'SuperMan'.
+	classDefinition instVarNames: #(ivar0).
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+]
+
+{ #category : 'tests-issue 353' }
+RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_E [
+
+	"new test case:superclass has new class version ... each subclass has methods removed"
+	"https://github.com/dalehenrich/Rowan/issues/353"
+
+	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue326'.
+	packageName := 'Issue326-Core'.
+	className1 := 'Issue326Class1'.
+	className2 := 'Issue326Class2'.
+	className3 := 'Issue326Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: 'SuperMan'
+			super: 'Object'
+			instvars: #(ivar0)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method4'
+					protocol: 'accessing'
+					source: 'method4 ^3').
+	classDefinition
+		addClassMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method5'
+					protocol: 'accessing'
+					source: 'method5 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method3'
+					protocol: 'accessing'
+					source: 'method3 ^3').
+	classDefinition
+		addClassMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method2'
+					protocol: 'accessing'
+					source: 'method2 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+
+"new class version of SuperMan and remove methods"
+	projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className1.
+	classDefinition
+		removeInstanceMethod: #method4;
+		removeClassMethod: #method5;
+		yourself.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className2.
+	classDefinition
+		removeInstanceMethod: #method3;
+		removeClassMethod: #method2;
+		yourself.
+
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: 'SuperMan'.
+	classDefinition instVarNames: #().
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	self assert: ((Rowan image loadedClassNamed: className1) loadedInstanceMethods values select: [:loadedMethod | loadedMethod selector == #method4 ]) isEmpty
+]
+
+{ #category : 'tests-issue 353' }
+RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_F [
+
+	"new test case:superclass has new class version ... each subclass has SOME methods removed"
+	"https://github.com/dalehenrich/Rowan/issues/353"
+
+	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+
+	projectName := 'Issue326'.
+	packageName := 'Issue326-Core'.
+	className1 := 'Issue326Class1'.
+	className2 := 'Issue326Class2'.
+	className3 := 'Issue326Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: 'SuperMan'
+			super: 'Object'
+			instvars: #(ivar0)
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method4'
+					protocol: 'accessing'
+					source: 'method4 ^3').
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method5'
+					protocol: 'accessing'
+					source: 'method5 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+	classDefinition := (RwClassDefinition
+		newForClassNamed: className2
+			super: 'SuperMan'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'category'
+			comment: 'comment'
+			pools: #()
+			type: 'normal')
+		yourself.
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method3'
+					protocol: 'accessing'
+					source: 'method3 ^3').
+	classDefinition
+		addInstanceMethodDefinition:
+			(RwMethodDefinition
+					newForSelector: #'method2'
+					protocol: 'accessing'
+					source: 'method2 ^2').
+
+	packageDefinition 
+		addClassDefinition: classDefinition.
+
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+
+"new class version of SuperMan and remove methods"
+	projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className1.
+	classDefinition
+		removeInstanceMethod: #method4;
+		yourself.
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: className2.
+	classDefinition
+		removeInstanceMethod: #method3;
+		yourself.
+
+	classDefinition := (projectDefinition packageNamed: packageName) classDefinitions at: 'SuperMan'.
+	classDefinition instVarNames: #().
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	self assert: ((Rowan image loadedClassNamed: className1) loadedInstanceMethods values select: [:loadedMethod | loadedMethod selector == #method4 ]) isEmpty
+]
+
 { #category : 'tests-issue 40' }
 RwRowanProjectIssuesTest >> testIssue40 [
 

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -7258,7 +7258,7 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7344,6 +7344,9 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 353' }
@@ -7353,7 +7356,7 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7437,6 +7440,9 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 353' }
@@ -7446,7 +7452,7 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7564,6 +7570,9 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 353' }
@@ -7573,7 +7582,7 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7693,16 +7702,19 @@ RwRowanProjectIssuesTest >> testIssue353_new_version_class_with_subclass_with_me
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
-{ #category : 'tests-issue 353' }
+{ #category : 'tests-issue 393' }
 RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_E [
 
 	"new test case:superclass has new class version ... each subclass has methods removed"
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7821,18 +7833,21 @@ RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_me
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
 "validate"
 	self assert: ((Rowan image loadedClassNamed: className1) loadedInstanceMethods values select: [:loadedMethod | loadedMethod selector == #method4 ]) isEmpty
 ]
 
-{ #category : 'tests-issue 353' }
+{ #category : 'tests-issue 393' }
 RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_method_deletion_F [
 
 	"new test case:superclass has new class version ... each subclass has SOME methods removed"
 	"https://github.com/dalehenrich/Rowan/issues/353"
 
 	| projectName  packageName projectDefinition classDefinition packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 newClass1 audit |
 
 	projectName := 'Issue326'.
 	packageName := 'Issue326-Core'.
@@ -7948,6 +7963,9 @@ RwRowanProjectIssuesTest >> testIssue393_new_version_class_with_subclass_with_me
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 
 "validate"
 	self assert: ((Rowan image loadedClassNamed: className1) loadedInstanceMethods values select: [:loadedMethod | loadedMethod selector == #method4 ]) isEmpty

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -66,9 +66,11 @@ RwClsAuditTool >> _auditLoadedClassProperties: aLoadedClass forBehavior: aBehavi
 		ifFalse: [self errorLog: res  add: aLoadedClass name -> 'Superclass is different from loaded class'].
 	((aLoadedClass propertyAt: 'instvars') = (aBehavior instVarNames collect: [:e | e asString]) ) 
 			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'instVarNames changed in compiled class v loaded class'].
+false ifTrue: [
 	((aLoadedClass propertyAt: 'classvars') = ((aBehavior.classVars ifNil: [SymbolDictionary new]) 
 			keys collect: [:e | e asString])  asArray) ifFalse: [
 				self errorLog: res  add: aLoadedClass name -> 'ClassVars changed in compiled class v loaded class'].
+].
 	((aLoadedClass propertyAt: 'pools') = ((aBehavior.poolDictionaries ifNil: [Array new]) collect: [:e | e asString]) ) 
 			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'PoolDictionaries changed in compiled class v loaded class'].
 	((aLoadedClass propertyAt: 'comment' ifAbsent: ['']) isEquivalent: aBehavior comment ) 
@@ -135,14 +137,13 @@ RwClsAuditTool >> auditLoadedClass: aLoadedClass [
 		"audit loaded class methods"
 		aLoadedClass 
 			loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClass :aLoadedMethod | (aBehavior compiledMethodAt: aLoadedMethod name otherwise: nil) 
-					ifNil: [(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:a | res add: a]]]
+					ifNil: [(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:a | self errorLog: res add: a ]]]
 
 			loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |(aBehavior class compiledMethodAt: aLoadedMethod name otherwise: nil) 
-					ifNil: [(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass)  ifNotNil: [:a | res add: a]]
+					ifNil: [(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass)  ifNotNil: [:a | self errorLog: res add: a ]]
 			]
 	].
 	^res
-
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -1,0 +1,159 @@
+Class {
+	#name : 'RwClsAuditTool',
+	#superclass : 'RwClassTool',
+	#category : 'Rowan-Tools-Core'
+}
+
+{ #category : 'other' }
+RwClsAuditTool >> _asClassPrefix: aBoolean [
+
+	^aBoolean ifTrue: ['class' ] ifFalse: ['']
+
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditCategory: category forBehavior: aBehavior loadedClass: aLoadedClass [
+	
+	^self _auditCategory: category selectors: (aBehavior selectorsIn: category)  forBehavior: aBehavior loadedClass: aLoadedClass
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditCategory: category selectors: aSelectorSet forBehavior: aBehavior loadedClass: aLoadedClass [
+	|  res |
+	
+		res := Array new.
+
+		aSelectorSet do: [:aSelector |
+				(
+					aBehavior isMeta
+						ifTrue: [	self  _auditClassSelector: aSelector forBehavior: aBehavior loadedClass: aLoadedClass ]
+						ifFalse: [ self  _auditSelector: aSelector forBehavior: aBehavior loadedClass: aLoadedClass]	
+				)  ifNotNil: [:aRes | self errorLog: res add: aRes]
+				
+		].
+
+		^res
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditClassSelector: aSelector forBehavior: aBehavior loadedClass: aLoadedClass [
+"audit a selector. verify compiled method matches loaded method reference return nil if no problem found"
+
+	^(aLoadedClass loadedMethodAt: aSelector isMeta:  true)
+			ifNil: [(aLoadedClass name ,  ' >> ', aSelector) -> 'Missing loaded classmethod'.]
+			ifNotNil: [:aLoadedMethod |
+				(aBehavior compiledMethodAt: aSelector  otherwise: nil) == aLoadedMethod handle 
+						ifFalse: [(aLoadedClass name ,  ' >> ', aSelector) -> 'Compiled classmethod is not identical to loaded class method ']
+			]
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditLoadedClassMethod: aLoadedMethod forBehavior: aClassOrMeta loadedClass: aLoadedClassOrExtension [
+"verify that compiled method is present for each loaded class method. return nil if no error"
+"we already check verifying selectors that compiled method matches loaded method"
+
+		^(aClassOrMeta compiledMethodAt: aLoadedMethod name otherwise: nil) 
+				isNil ifTrue: [(aLoadedClassOrExtension name ,  ' >> ', aLoadedMethod name) -> 'Missing compiled classmethod: ' ]
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditLoadedClassProperties: aLoadedClass forBehavior: aBehavior [
+"Check #( 'instvars', 'superclass', 'classinstvars',  'gs_SymbolDictionary', 'comment', 'classvars', 'pools', 'category')"
+
+	| res  aDict |
+	res := Array new.
+	((aLoadedClass propertyAt: 'superclass') isEquivalent: aBehavior superclass name ) 
+		ifFalse: [self errorLog: res  add: aLoadedClass name -> 'Superclass is different from loaded class'].
+	((aLoadedClass propertyAt: 'instvars') = (aBehavior instVarNames collect: [:e | e asString]) ) 
+			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'instVarNames changed in compiled class v loaded class'].
+	((aLoadedClass propertyAt: 'classvars') = ((aBehavior.classVars ifNil: [SymbolDictionary new]) 
+			keys collect: [:e | e asString])  asArray) ifFalse: [
+				self errorLog: res  add: aLoadedClass name -> 'ClassVars changed in compiled class v loaded class'].
+	((aLoadedClass propertyAt: 'pools') = ((aBehavior.poolDictionaries ifNil: [Array new]) collect: [:e | e asString]) ) 
+			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'PoolDictionaries changed in compiled class v loaded class'].
+	((aLoadedClass propertyAt: 'comment' ifAbsent: ['']) isEquivalent: aBehavior comment ) 
+			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'Comment has changed in compiled class v loaded class'].
+	((aLoadedClass propertyAt: 'category') = aBehavior category ) 
+			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'Class category has changed in compiled class v loaded class'].
+	(aDict := System myUserProfile resolveSymbol: (aLoadedClass propertyAt: 'gs_SymbolDictionary') asSymbol ) 
+			ifNil: [self errorLog: res  add: 'Unable to find SymbolDictionary for LoadedClass'] 
+			ifNotNil: [:smbd | smbd value at: aLoadedClass name asSymbol 
+					ifAbsent: [self errorLog: res  add: aLoadedClass name -> 'Compiled class not found in symbol dictionary of loaded class']] .
+
+^res
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aClassOrMeta loadedClass: aLoadedClassOrExtension [
+"verify that compiled method is present for each loaded instance method. return nil if no error"
+"we already check verifying selectors that compiled method matches loaded method"
+
+		^(aClassOrMeta compiledMethodAt: aLoadedMethod name  otherwise: nil) 
+				isNil ifTrue: [(aLoadedClassOrExtension name ,  ' >> ', aLoadedMethod name) -> 'Missing compiled instance method ' ]
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> _auditSelector: aSelector forBehavior: aBehavior loadedClass: aLoadedClass [
+"audit an instance selector. return nil if no problem found"
+
+	^(aLoadedClass loadedMethodAt: aSelector isMeta:  false)
+			ifNil: [(aLoadedClass name ,  ' >> ', aSelector) -> 'Missing loaded instance method'.]
+			ifNotNil: [:aLoadedMethod |
+				(aBehavior compiledMethodAt: aSelector  otherwise: nil) == aLoadedMethod handle 
+							ifFalse: [(aLoadedClass name ,  ' >> ', aSelector) -> 'Compiled instance method is not identical to loaded method']
+			]
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> auditLoadedClass: aLoadedClass [
+"look for methods compiled into class without Rowan API"
+| res  |
+
+	res := StringKeyValueDictionary new.
+	(Rowan globalNamed: aLoadedClass name)  
+		ifNil: [self errorLog: res add: aLoadedClass name -> 'Matching class does not exists ' ] "there is no matching Class for LoadedClass"
+		ifNotNil: [:aBehavior | 
+			"audit class properties"
+			res addAll: (self _auditLoadedClassProperties: aLoadedClass forBehavior: aBehavior).
+			"audit categories"
+
+			aBehavior categorysDo: [:category :selectors | 
+				category first == $*	ifTrue: [
+						((category copyFrom: 2 to: category size) isEquivalent: aBehavior rowanPackageName) 
+							ifTrue: [self errorLog: res add: category asString -> 'Extension category name can be same as class category' ]
+					] ifFalse: [
+						self errorLog: res addAll: (self  _auditCategory: category selectors: selectors forBehavior: aBehavior loadedClass: aLoadedClass)]
+			].
+			aBehavior class categorysDo: [:category :selectors | 
+				category first == $* 	ifTrue: [
+						((category copyFrom: 2 to: category size)  isEquivalent: aBehavior rowanPackageName) 
+							ifTrue: [self errorLog: res add: category asString -> 'Extension category name can be same as class category' ]
+					] ifFalse: [
+					self errorLog: res  addAll: (self  _auditCategory: category selectors: selectors forBehavior: aBehavior class loadedClass: aLoadedClass)
+				]
+			].
+		"audit loaded class methods"
+		aLoadedClass 
+			loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClass :aLoadedMethod | (aBehavior compiledMethodAt: aLoadedMethod name) 
+					ifNil: [(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:a | res add: a]]]
+
+			loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |(aBehavior class compiledMethodAt: aLoadedMethod name) 
+					ifNil: [(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass)  ifNotNil: [:a | res add: a]]
+			]
+	].
+	^res
+
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> errorLog: aResult add: aMessage [	
+"add error to results. print to file"
+	aResult add: aMessage.
+	GsFile gciLogServer: aMessage key asString , ' -> ' ,aMessage value asString.
+]
+
+{ #category : 'other' }
+RwClsAuditTool >> errorLog: aResult addAll: aCol [	
+"add all messages to result"
+	aCol do: [:e | self errorLog: aResult add: e].
+]

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -134,10 +134,10 @@ RwClsAuditTool >> auditLoadedClass: aLoadedClass [
 			].
 		"audit loaded class methods"
 		aLoadedClass 
-			loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClass :aLoadedMethod | (aBehavior compiledMethodAt: aLoadedMethod name) 
+			loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClass :aLoadedMethod | (aBehavior compiledMethodAt: aLoadedMethod name otherwise: nil) 
 					ifNil: [(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:a | res add: a]]]
 
-			loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |(aBehavior class compiledMethodAt: aLoadedMethod name) 
+			loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |(aBehavior class compiledMethodAt: aLoadedMethod name otherwise: nil) 
 					ifNil: [(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass)  ifNotNil: [:a | res add: a]]
 			]
 	].

--- a/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
@@ -32,23 +32,24 @@ RwClsExtensionAuditTool >> auditLoadedClassExtenstion: aLoadedClassExtension [
 		ifNil: [self errorLog: res  add: aLoadedClassExtension name -> 'Matching compiled class does not exists '] 
 		ifNotNil: [:aBehavior | 
 			
+false ifTrue: [ 
 			self errorLog: res addAll:  ((aBehavior includesCategory: extensionCategoryName)
 				ifTrue: [(self _auditCategory: extensionCategoryName forBehavior: aBehavior loadedClass: aLoadedClassExtension)]
 				ifFalse: [
 					(aBehavior class includesCategory: extensionCategoryName)
 						ifTrue: [(self _auditCategory: extensionCategoryName forBehavior: aBehavior class loadedClass: aLoadedClassExtension)]
-						ifFalse: [ { extensionCategoryName -> 'Missing extension category'} ]
+						ifFalse: [ { extensionCategoryName -> ('Missing extension category in class  ', aBehavior name printString)} ]
 			]).
+].
 
 			
 			aLoadedClassExtension 
 				loadedInstanceMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod | 
-					(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:x | res add: x]
+					(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:x | self errorLog: res add: x]
 				] 
 				loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |
-					(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass) ifNotNil: [:x | res add: x]
+					(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass) ifNotNil: [:x | self errorLog: res add: x]
 				]
 		].
 		^res
-
 ]

--- a/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : 'RwClsExtensionAuditTool',
+	#superclass : 'RwClsAuditTool',
+	#category : 'Rowan-Tools-Core'
+}
+
+{ #category : 'other' }
+RwClsExtensionAuditTool >> _auditCategory: anExtentionCategory forBehavior: aClassOrMeta loadedClass: aLoadedClassExtension [
+"if we have loaded methods but no compiled methods add error to result"
+| res |
+	res := super _auditCategory: anExtentionCategory forBehavior: aClassOrMeta loadedClass: aLoadedClassExtension.
+	aClassOrMeta isMeta 
+		ifTrue: [
+			(aLoadedClassExtension loadedClassMethods notEmpty and: [(aClassOrMeta selectorsIn: anExtentionCategory) isEmpty])
+				ifTrue: [ self errorLog: res  add: ((anExtentionCategory asString -> 'expected class methods in the category are missing'))   ].
+	] 	ifFalse: [
+			(aLoadedClassExtension loadedInstanceMethods notEmpty and: [(aClassOrMeta selectorsIn: anExtentionCategory) isEmpty])
+				ifTrue: [ self errorLog: res  add: (anExtentionCategory asString -> ('expected instances methods in the category are missing'))   ].
+	].
+	^res
+
+]
+
+{ #category : 'other' }
+RwClsExtensionAuditTool >> auditLoadedClassExtenstion: aLoadedClassExtension [
+"look for methods compiled into class without Rowan API"
+| res   extensionCategoryName|
+
+	res := StringKeyValueDictionary new.
+	extensionCategoryName := aLoadedClassExtension loadedPackage asExtensionName.
+	(Rowan globalNamed: aLoadedClassExtension name) 
+		ifNil: [self errorLog: res  add: aLoadedClassExtension name -> 'Matching compiled class does not exists '] 
+		ifNotNil: [:aBehavior | 
+			
+			self errorLog: res addAll:  ((aBehavior includesCategory: extensionCategoryName)
+				ifTrue: [(self _auditCategory: extensionCategoryName forBehavior: aBehavior loadedClass: aLoadedClassExtension)]
+				ifFalse: [
+					(aBehavior class includesCategory: extensionCategoryName)
+						ifTrue: [(self _auditCategory: extensionCategoryName forBehavior: aBehavior class loadedClass: aLoadedClassExtension)]
+						ifFalse: [ { extensionCategoryName -> 'Missing extension category'} ]
+			]).
+
+			
+			aLoadedClassExtension 
+				loadedInstanceMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod | 
+					(self _auditLoadedInstanceMethod: aLoadedMethod forBehavior: aBehavior loadedClass: loadedClass) ifNotNil: [:x | res add: x]
+				] 
+				loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |
+					(self _auditLoadedClassMethod: aLoadedMethod forBehavior: aBehavior class loadedClass: loadedClass) ifNotNil: [:x | res add: x]
+				]
+		].
+		^res
+
+]

--- a/rowan/src/Rowan-Tools-Core/RwPackageTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPackageTool.class.st
@@ -7,6 +7,11 @@ Class {
 { #category : 'commands' }
 RwPackageTool class >> adopt [
   ^ RwPkgAdoptTool new
+]
+
+{ #category : 'commands' }
+RwPackageTool class >> audit [
+  ^ RwPkgAuditTool new
 
 ]
 

--- a/rowan/src/Rowan-Tools-Core/RwPkgAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPkgAuditTool.class.st
@@ -16,7 +16,8 @@ RwPkgAuditTool >> auditForPackage: loadedPackage [
 "audit dirty packages"
 	|  res|
 	res := KeyValueDictionary new.
-	(loadedPackage isDirty or: [self checkAll]) ifTrue: [
+	true ifTrue: [
+	"(loadedPackage isDirty or: [self checkAll]) ifTrue: ["
 		loadedPackage 
 				loadedClassesDo: [:aLoadedClass |  (self auditLoadedClass: aLoadedClass) 
 					ifNotEmpty: [:aColl | res at: aLoadedClass name put: aColl]]				

--- a/rowan/src/Rowan-Tools-Core/RwPkgAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPkgAuditTool.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : 'RwPkgAuditTool',
+	#superclass : 'RwAbstractTool',
+	#category : 'Rowan-Tools-Core'
+}
+
+{ #category : 'other' }
+RwPkgAuditTool >> _addAll: aColl to: aDict for: aName [
+
+	aDict at: aName ifAbsentPut: [aColl].
+
+]
+
+{ #category : 'other' }
+RwPkgAuditTool >> auditForPackage: loadedPackage [
+"audit dirty packages"
+	|  res|
+	res := KeyValueDictionary new.
+	(loadedPackage isDirty or: [self checkAll]) ifTrue: [
+		loadedPackage 
+				loadedClassesDo: [:aLoadedClass |  (self auditLoadedClass: aLoadedClass) 
+					ifNotEmpty: [:aColl | res at: aLoadedClass name put: aColl]]				
+				loadedClassExtensionsDo: [:aLoadedClass | (self auditLoadedClassExtenstion: aLoadedClass) 
+					ifNotEmpty: [:aColl | res at: aLoadedClass name put: aColl] ] .
+	].
+	^res
+]
+
+{ #category : 'other' }
+RwPkgAuditTool >> auditForPackageNamed: packageName [
+	
+	^self auditForPackage: (Rowan image loadedPackageNamed: packageName).
+
+]
+
+{ #category : 'other' }
+RwPkgAuditTool >> auditLoadedClass: aLoadedClass [
+"look for methods compiled into class without Rowan API"
+
+	^RwClsAuditTool new auditLoadedClass: aLoadedClass.
+
+]
+
+{ #category : 'other' }
+RwPkgAuditTool >> auditLoadedClassExtenstion: aLoadedClass [
+"look for methods compiled into class without Rowan API"
+
+	^RwClsExtensionAuditTool new auditLoadedClassExtenstion: aLoadedClass
+
+]
+
+{ #category : 'other' }
+RwPkgAuditTool >> checkAll [
+"check all packages regardless dirty or not"
+	^(SessionTemps current at: #RwDirtyOnly otherwise: false) not
+
+]

--- a/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
@@ -24,12 +24,9 @@ RwPrjAuditTool >> auditForProject: aLoadedProject [
 	| res |
 
 	res := KeyValueDictionary new.
-	aLoadedProject isDirty ifTrue: [
-		aLoadedProject loadedPackages values do: [:e | (Rowan packageTools audit auditForPackage: e) 
-				ifNotEmpty: [:aColl | res at: e name put: aColl]].	
-	].
+	aLoadedProject loadedPackages values do: [:e | (Rowan packageTools audit auditForPackage: e) 
+		ifNotEmpty: [:aColl | res at: e name put: aColl]].	
 	^res
-
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
@@ -1,0 +1,62 @@
+Class {
+	#name : 'RwPrjAuditTool',
+	#superclass : 'RwProjectTool',
+	#category : 'Rowan-Tools-Core'
+}
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditAll [
+| res |
+	res := KeyValueDictionary halt new.
+	System myUserProfile symbolList do: [:aSmbDict | 
+			(Rowan image  _loadedProjectRegistryForUserId: System myUserProfile userId) keysAndValuesDo: [:prjName :aLoadedProject |
+				(self auditForProject: aLoadedProject) ifNotEmpty: [:aColl | res at: prjName put: aColl]
+			]
+	].
+	^res
+
+]
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditForProject: aLoadedProject [
+"audit loaded project"
+
+	| res |
+
+	res := KeyValueDictionary new.
+	aLoadedProject isDirty ifTrue: [
+		aLoadedProject loadedPackages values do: [:e | (Rowan packageTools audit auditForPackage: e) 
+				ifNotEmpty: [:aColl | res at: e name put: aColl]].	
+	].
+	^res
+
+]
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditForProjectNamed: aProjectName [
+
+	^self auditForProject: (Rowan image loadedProjectNamed: aProjectName)
+
+]
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditForProjectsNamed: aCol [
+"audit all named projects"
+	
+	| res |
+	res := Array new.
+		aCol do: [:prjName | res addAll: (self auditForProjectNamed: prjName )	].
+	^res
+
+]
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditProjectsNamed: aCol [
+"audit all named projects"
+	
+	| res |
+	res := Array new.
+		aCol do: [:prjName | res addAll: (self auditForProjectNamed: prjName )	].
+	^res
+
+]

--- a/rowan/src/Rowan-Tools-Core/RwPrjDeleteTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjDeleteTool.class.st
@@ -117,7 +117,7 @@ RwPrjDeleteTool >> forceDeleteProjectSetDefinition: projectSetDefinitionToDelete
 			loadedClassedDo: [ :loadedProject :loadedPackage :loadedClass | 
 				"collect the classes defined in the project"
 				classesToDelete add: loadedClass handle currentVersion ] 
-			loadedClassExtenstionsDo: [:loadedProject :loadedPackage :loadedClassExtension | "ignored" ] 
+			loadedClassExtensionsDo: [:loadedProject :loadedPackage :loadedClassExtension | "ignored" ] 
 			loadedInstanceMethodsDo: [:loadedProject :loadedPackage :loadedClassOrClassExtension :loadedMethod |
 				loadedClassOrClassExtension isLoadedClassExtension
 					ifTrue: [ 
@@ -158,5 +158,4 @@ RwPrjDeleteTool >> forceDeleteProjectSetDefinition: projectSetDefinitionToDelete
 		(selectorDict at: 'class' ifAbsent: [ #() ]) do: [:selector |
 			GsFile gciLogServer: '		', selector asString printString.
 			behavior removeSelector: selector ] ].
-
 ]

--- a/rowan/src/Rowan-Tools-Core/RwProjectTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwProjectTool.class.st
@@ -8,6 +8,12 @@ Class {
 RwProjectTool class >> adopt [
 
 	^ RwPrjAdoptTool new
+]
+
+{ #category : 'commands' }
+RwProjectTool class >> audit [
+
+	^RwPrjAuditTool new
 
 ]
 

--- a/rowan/src/Rowan-Tools/RwPkgAuditTool.class.st
+++ b/rowan/src/Rowan-Tools/RwPkgAuditTool.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : 'RwPkgAuditTool',
-	#superclass : 'RwAbstractTool',
-	#category : 'Rowan-Tools'
-}


### PR DESCRIPTION
## v1.2.2
### Merges
1. [v1.2.1 release merge](https://github.com/GemTalk/Rowan/pull/391)
### New Features
1. Issue #374 - "audit tools improvements"
### Bugfixes
1. Issue #393 - "upgrading Rowan v1.2.0 to v1.2.1 results in Rowan structure corruption... "
2. Issue #365 - "Need support for case where Global extension methods used by Rowan have been corrupted by external process"
2. Issue #353 - "internal error - unexpected method deletion (delete methods from a class whose superclass has a new version)"
## [v1.2.1](https://github.com/GemTalk/Rowan/pull/391)
### Merges
1. [v1.1.1 release merged](https://github.com/GemTalk/Rowan/releases/tag/v1.1.1)
### Fixes
1. Issue #384 - "Need script to create a db with several thousand classes and several hundred packages" _+ performance improvements in Jadeite
1. Issue #370 - "Tonel and STON tests should be passing"
2. Issue #368 - "Include JadeServer classes as part of bootstrap "
3. Issue #365 - "Need support for case where Global extension methods used by Rowan have been corrupted by external process"
2. Issue #359 - "Rowan should not use Deprecated APIs"
2. Issue #356 - "Cannot login as user with no defaultObjectSecurityPolicy (nil) ... like Ernie"
3. Issue #355 - "Cannot log into a server after running the full test suite..."

### Partial fixes
1. Issue #349 - "transient symbol list maintains reference to newly added symbol dictionary after abort "
   - tests and RowanSample1 adjusted so as to not trigger this bug