### PR TITLE
v1.1.3 release

### DIFF
--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_365
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_365
@@ -13,8 +13,6 @@ startTopaz $GEMSTONE_NAME -l << EOF
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
 
   set u SystemUser p swordfish
   login

--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_399
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_399
@@ -8,10 +8,6 @@ export ROWAN_HOME="$(dirname $0)/../../../../"
 
 startTopaz $GEMSTONE_NAME -l << EOF
 
-
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/install_issue_365.tpz
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_365.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
@@ -24,7 +20,7 @@ startTopaz $GEMSTONE_NAME -l << EOF
 	true
 		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
 	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
-		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_365_results'' or log file for details.' ].
+		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
 	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
 	System commit
 %

--- a/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
@@ -45,11 +45,21 @@ output pushnew audit_issue_365.out
 				aLoadedClass 
 					loadedInstanceMethodsDo: [ :loadedProject :loadedPackage :loadedClass :aLoadedMethod | 
 						(aBehavior compiledMethodAt: aLoadedMethod name otherwise: nil) 
+							ifNotNil: [:lm | 
+								(Rowan image loadedMethodForMethod: lm ifAbsent: [])
+									ifNil: [
+										ar addAll: { 'Loaded method not registered'  -> (aLoadedClass name, '>>', aLoadedMethod name)  }.
+										GsFile gciLogServer: 'Loaded method not registered ', aLoadedClass name, '>>', aLoadedMethod name ] ]
 							ifNil: [
 								ar addAll: { aLoadedMethod name  -> 'Missing compiled method: ' }.
 								GsFile gciLogServer: 'Missing compiled method ', loadedClass name, '>>', aLoadedMethod name ] ]
 					loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |
 						(aBehavior class compiledMethodAt: aLoadedMethod name otherwise: nil) 
+							ifNotNil: [:lm | 
+								(Rowan image loadedMethodForMethod: lm ifAbsent: []) 
+									ifNil: [
+										ar addAll: { 'Loaded class method not registered'  -> (aLoadedClass name,  ' class>>', aLoadedMethod name)  }.
+										GsFile gciLogServer: 'Loaded class method not registered ', aLoadedClass name,  ' class>>', aLoadedMethod name ] ]
 							ifNil: [
 								ar addAll: { aLoadedMethod name  -> 'Missing compiled classmethod ' }.
 								GsFile gciLogServer: 'Missing compiled method ', loadedClass name, ' class>>', aLoadedMethod name ] ] ].
@@ -139,11 +149,21 @@ output pushnew audit_issue_365.out
 				aLoadedClassExtension 
 					loadedInstanceMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod | 
 						(aBehavior compiledMethodAt: aLoadedMethod name otherwise: nil) 
+							ifNotNil: [:lm | 
+								(Rowan image loadedMethodForMethod: lm ifAbsent: [])
+									ifNil: [
+										ar addAll: { 'Loaded extension method not registered'  -> (aLoadedClassExtension name, '>>', aLoadedMethod name)  }.
+										GsFile gciLogServer: 'Loaded extension method not registered ', aLoadedClassExtension name, '>>', aLoadedMethod name ] ]
 							ifNil: [
 								ar addAll: {aLoadedMethod name -> 'Missing compiled method: ' }.
 								GsFile gciLogServer: 'Missing compiled  method ', loadedClass name, '>>', aLoadedMethod name ] ]
 					loadedClassMethodsDo: [:loadedProject :loadedPackage :loadedClass :aLoadedMethod |
 						(aBehavior class compiledMethodAt: aLoadedMethod name otherwise: nil) 
+							ifNotNil: [:lm | 
+								(Rowan image loadedMethodForMethod: lm ifAbsent: []) 
+									ifNil: [
+										ar addAll: { 'Loaded class extension method not registered'  -> (aLoadedClassExtension name,  ' class>>', aLoadedMethod name)  }.
+										GsFile gciLogServer: 'Loaded class extension method not registered ', aLoadedClassExtension name,  ' class>>', aLoadedMethod name ] ]
 							ifNil: [
 								ar addAll: { aLoadedMethod name -> 'Missing compiled class method: ' }.
 								GsFile gciLogServer: 'Missing compiled  class method ', loadedClass name, ' class>>', aLoadedMethod name ] ] ].

--- a/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
@@ -10,7 +10,6 @@ output pushnew audit_issue_365.out
 	run
 	|  res loadedPackage loadedProject auditLoadedClassBlock auditLoadedClassExtensionBlock |
 	GsFile gciLogServer: '--STARTING ROWAN AUDIT'.
-	res := KeyValueDictionary new.
 	auditLoadedClassBlock := [:aLoadedClass |
 		| ar |
 		ar := {}.
@@ -19,6 +18,16 @@ output pushnew audit_issue_365.out
 				ar addAll: { 'Class does not exists ' -> aLoadedClass name }.
 				GsFile gciLogServer: 'Class does not exist ', aLoadedClass name ]
 			ifNotNil: [:aBehavior |
+				| lc |
+				(lc := Rowan image loadedClassNamed: aLoadedClass name ifAbsent: []) == aLoadedClass
+					ifFalse: [
+						lc isNil
+							ifTrue: [ 
+								ar addAll: { 'Loaded class not registered'  -> aLoadedClass name  }.
+								GsFile gciLogServer: 'Loaded class not registered ', aLoadedClass name ]
+							ifFalse: [ 
+								ar addAll: { 'Loaded class not identical to registered class '  -> aLoadedClass name  }.
+								GsFile gciLogServer: 'Loaded class not identical to registered class ', aLoadedClass name ] ].
 				"check for non-extension methods that are not packaged in Rowan" 
 				(aBehavior selectors reject: [:e |  
 					((aBehavior categoryOfSelector: e) first == $*) or: [
@@ -54,7 +63,18 @@ output pushnew audit_issue_365.out
 				ar addAll: { 'Class does not exists '-> aLoadedClassExtension name }.
 				GsFile gciLogServer: 'Class does not exist ', aLoadedClassExtension name ]
 			ifNotNil: [ :aBehavior |
-				| selectors extensionCategoryName |
+				| selectors extensionCategoryName les |
+				les := nil.
+				((Rowan image loadedClassExtensionsNamed: aLoadedClassExtension name ifFound: [:set | les := set ]  ifAbsent: [ #() ]) includesIdentical: aLoadedClassExtension)
+					ifFalse: [
+						les isNil
+							ifTrue: [ 
+								ar addAll: { 'Loaded class extension not registered'  -> aLoadedClassExtension name  }.
+								GsFile gciLogServer: 'Loaded class not registered ', aLoadedClassExtension name ]
+							ifFalse: [ 
+								ar addAll: { 'Loaded class extension not identical to registered class '  -> aLoadedClassExtension name  }.
+								GsFile gciLogServer: 'Loaded class not identical to registered class ', aLoadedClassExtension name ] ].
+
 				extensionCategoryName := '*', aLoadedClassExtension loadedPackage name asLowercase.
 
 				((aBehavior _baseCategorys: 0) keys
@@ -129,10 +149,23 @@ output pushnew audit_issue_365.out
 								GsFile gciLogServer: 'Missing compiled  class method ', loadedClass name, ' class>>', aLoadedMethod name ] ] ].
 		ar ].
 		
+
+	res := Dictionary new.
 	Rowan projectNames do: [:projectName |
 		GsFile gciLogServer: '---Auditing project: ', projectName printString.
 		loadedProject := Rowan image loadedProjectNamed: projectName.
 		loadedProject loadedPackages do: [:loadedPackage |
+			| lp |
+			GsFile gciLogServer: ' --Auditing package: ', loadedPackage name printString.
+			(lp := Rowan image loadedPackageNamed: loadedPackage name ifAbsent: []) == loadedPackage
+				ifFalse: [
+					lp isNil
+						ifTrue: [ 
+							res at: 'Package:', loadedPackage name put: { loadedPackage name  -> ' is missing from the package registry.' }.
+							GsFile gciLogServer: 'The package', loadedPackage name printString, ' is missing from the package registry.' ] 
+						ifFalse: [ 
+							res at: 'Package:', loadedPackage name put: { loadedPackage name  -> ' is not identical to the registered package.' }.
+							GsFile gciLogServer: 'The package', loadedPackage name printString, ' is not identical to the registered loaded package' ] ].
 			loadedPackage
 				loadedClasses
 					valuesDo: [:aLoadedClass |

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
@@ -1,4 +1,4 @@
-output push patch_issue_365.out
+output push patch_issue_399.out
 
   iferr 1 stk
   iferr 2 stack
@@ -9,6 +9,7 @@ output push patch_issue_365.out
   login
 
 	run
+	| ug |
 	"patch missing RwSymbolDictionaryRegistry in UserGlobals"
 	(UserGlobals at: #RwSymbolDictionaryRegistry ifAbsent: []) 
 		ifNotNil: [
@@ -16,23 +17,72 @@ output push patch_issue_365.out
 			^ true ].
 	GsFile gciLogServer: '---Patching missing RwSymbolDictionaryRegistry in UserGlobals'.
 
+	ug := Rowan image newOrExistingSymbolDictionaryNamed: 'UserGlobals'. "will create new registry if needed"
 	Rowan projectNames do: [:projectName |
-		| project loadedProject |
+		| project loadedProject registry packageRegistry classRegistry classExtensionRegistry methodRegistry |
 		GsFile gciLogServer: '---Checking project: ', projectName printString.
 		project := RwProject newNamed: projectName.
+		registry := ug rowanSymbolDictionaryRegistry.
+		packageRegistry := registry packageRegistry.
+		classRegistry := registry classRegistry.
+		classExtensionRegistry := registry classExtensionRegistry.
+		methodRegistry := registry methodRegistry.
 		loadedProject := Rowan image loadedProjectNamed: projectName.
 		loadedProject loadedPackages do: [:loadedPackage |
 			(project symbolDictNameForPackageNamed: loadedPackage name) == #UserGlobals
 				ifTrue: [
+					packageRegistry 
+						at: loadedPackage name 
+						ifAbsentPut: [
+							GsFile gciLogServer: 'Patch loaded package ', loadedPackage printString.
+							loadedPackage ].
 
 					loadedPackage
 						loadedClasses
 							valuesDo: [:aLoadedClass |
-								 ].
+								classRegistry 
+									at: aLoadedClass handle classHistory 
+									ifAbsentPut: [
+										GsFile gciLogServer: 'Patch loaded class ', aLoadedClass printString.
+										aLoadedClass ].
+
+								aLoadedClass
+									loadedInstanceMethods valuesDo: [:loadedMethod |
+										methodRegistry 
+											at: loadedMethod handle 
+											ifAbsentPut: [
+												GsFile gciLogServer: 'Patch loaded method ', aLoadedClass name, '>>', loadedMethod selector.
+												loadedMethod ] ].
+								aLoadedClass
+									loadedClassMethods valuesDo: [:loadedMethod |
+										methodRegistry 
+											at: loadedMethod handle 
+											ifAbsentPut: [
+												GsFile gciLogServer: 'Patch loaded method ', aLoadedClass name, '>>', loadedMethod selector.
+												loadedMethod ] ] ].
 					loadedPackage
 						loadedClassExtensions
 							valuesDo: [:aLoadedClass | 
-								 ] ] ] ].
+								classExtensionRegistry 
+									at: aLoadedClass handle classHistory 
+									ifAbsentPut: [
+										GsFile gciLogServer: 'Patch loaded class extension ', aLoadedClass printString.
+										aLoadedClass ].
+
+								aLoadedClass
+									loadedInstanceMethods valuesDo: [:loadedMethod |
+										methodRegistry 
+											at: loadedMethod handle 
+											ifAbsentPut: [
+												GsFile gciLogServer: 'Patch loaded extension method ', aLoadedClass name, ' class>>', loadedMethod selector.
+												loadedMethod ] ].
+								aLoadedClass
+									loadedClassMethods valuesDo: [:loadedMethod |
+										methodRegistry 
+											at: loadedMethod handle 
+											ifAbsentPut: [
+												GsFile gciLogServer: 'Patch loaded extension method ', aLoadedClass name, ' class>>', loadedMethod selector.
+												loadedMethod] ] ] ] ] ].
 
 	GsFile gciLogServer: '--Finished Patching missing RwSymbolDictionaryRegistry'.
 	true

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
@@ -29,8 +29,14 @@ output push patch_issue_399.out
 		methodRegistry := registry methodRegistry.
 		loadedProject := Rowan image loadedProjectNamed: projectName.
 		loadedProject loadedPackages do: [:loadedPackage |
-			(project symbolDictNameForPackageNamed: loadedPackage name) == #UserGlobals
+			| symDictName |
+			symDictName := project symbolDictNameForPackageNamed: loadedPackage name.
+			GsFile gciLogServer: ' --Checking package: ', loadedPackage name printString.
+			(symDictName = 'UserGlobals')
 				ifTrue: [
+
+					GsFile gciLogServer: ' -Repairing package: ', loadedPackage name printString.
+
 					packageRegistry 
 						at: loadedPackage name 
 						ifAbsentPut: [

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
@@ -1,0 +1,47 @@
+output push patch_issue_365.out
+
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit 1
+	display oops
+
+  set u SystemUser p swordfish
+  login
+
+	run
+	"patch missing RwSymbolDictionaryRegistry in UserGlobals"
+	(UserGlobals at: #RwSymbolDictionaryRegistry ifAbsent: []) 
+		ifNotNil: [
+			GsFile gciLogServer: '---RwSymbolDictionaryRegistry is present in UserGlobals'.
+			^ true ].
+	GsFile gciLogServer: '---Patching missing RwSymbolDictionaryRegistry in UserGlobals'.
+
+	Rowan projectNames do: [:projectName |
+		| project loadedProject |
+		GsFile gciLogServer: '---Checking project: ', projectName printString.
+		project := RwProject newNamed: projectName.
+		loadedProject := Rowan image loadedProjectNamed: projectName.
+		loadedProject loadedPackages do: [:loadedPackage |
+			(project symbolDictNameForPackageNamed: loadedPackage name) == #UserGlobals
+				ifTrue: [
+
+					loadedPackage
+						loadedClasses
+							valuesDo: [:aLoadedClass |
+								 ].
+					loadedPackage
+						loadedClassExtensions
+							valuesDo: [:aLoadedClass | 
+								 ] ] ] ].
+
+	GsFile gciLogServer: '--Finished Patching missing RwSymbolDictionaryRegistry'.
+	true
+%
+  commit
+
+errorCount
+
+  logout
+
+output pop
+


### PR DESCRIPTION
No modifications were made to the Rowan code base ... only supporting scripts for audit and patching have been changed/added.
### Bugfixes
1. Issue #399 - "Need to be able to audit and repair missing #'RwSymbolDictionaryRegistry' in a symbol dictionary"

   - Block based audit script has been updated to detect missing RwSymbolDictionaryRegistry in a SymbolDictionary.
   - To repair missing RwSymbolDictionaryRegistry in UserGlobals (script should be modified to repair a different SymbolDictionary than UserGlobals), use the following topax script
```
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_399.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz

  set u SystemUser p swordfish
  login
! Rowan Audit should run clean
	run
	"Known issue with Rowan package structure ... will be addressed separately"
	true
		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
	System commit
%
	errorCount
  exit
```