### PR TITLE
v1.1.5 release

### DIFF
--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -23,6 +23,8 @@ set -e
 # 1.1.1 candidate $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate v1.1.1-candidate Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.1 candidate 2 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate_2 v1.1.1-candidate_2 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.1 candidate 3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate_3 v1.1.1-candidate_3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.1.3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.3 v1.1.3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.1.4 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.4 v1.1.4 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"
@@ -37,8 +39,8 @@ rowan_tag="$2"
 jadeite_tag="$3"
 sett_zip_location="$4"
 sett_zip=$(basename ${sett_zip_location})
-rowanDeploymentBranch="masterV1.1"
 rowanDeploymentBranch="candidateV1.1"
+rowanDeploymentBranch="masterV1.1"
 
 commit_match_tag() {
   targetTag="$1"

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
@@ -16,10 +16,18 @@ output push patch_issue_406.out
   login
 
 	run
-	#('Cypress' 'Tonel' 'STON' 'Rowan') do: [:projectName |
+	| loadedProject |
+	#('Cypress' 'Tonel' 'STON') do: [:projectName |
 		GsFile gciLogServer: 'Disown ', projectName.
 		Rowan projectTools disown
 			disownProjectNamed: projectName ].
+	loadedProject := Rowan image loadedProjectNamed: 'Rowan'.
+	loadedProject loadedPackages do: [:loadedPackage |
+		loadedPackage name = 'Rowan-JadeServer'
+			ifTrue: [ 
+				(Rowan image loadedRegistryForPackageNamed: loadedPackage name) 
+					deletePackage: loadedPackage name ]
+			ifFalse: [ Rowan packageTools disown disownPackageNamed: loadedPackage name ] ].
 %
   commit
 

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
@@ -56,7 +56,9 @@ output push patch_issue_406.out
 		ar size = 1
 			ifTrue: [
 				| theProjectSetDefinition |
-				theProjectSetDefinition := readTool readProjectSetForProjectNamed: specification specName.
+				theProjectSetDefinition := readTool 
+					readProjectSetForProjectNamed: specification specName  
+					withGroupNames: #('core'  'tests' 'deprecated'). "skip reading jadeServer group, since JadeServer classes missing"
 				theProjectSetDefinition
 					do: [:projectDefinition |
 						projectSetDefinition addProject: projectDefinition ].
@@ -124,8 +126,14 @@ output push patch_issue_406.out
 		"mark projects and packages not dirty"
 		loadedProject markNotDirty.
 		loadedProject loadedPackages valuesDo: [:loadedPackage | loadedPackage markNotDirty ] ].
+
+	"Now reload Rowan including jadeServer group to get JadeServer classes properly installed"
+	Rowan projectTools load
+			loadProjectNamed: 'Rowan'
+			withGroupNames: #('core' 'tests' 'deprecated' 'jadeServer') 
 	
 %
+
   commit
 
 errorCount


### PR DESCRIPTION
No modifications were made to the Rowan code base ... only supporting scripts for audit and patching have been changed/added.
### Bugfixes
1. Issue #406 - "patch script repairs install Rowan on top of Rowan"
   - includes additional patch for manual removal of JadeServer classes after double install
### Topaz patch script
```
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/install_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz

  set u SystemUser p swordfish
  login
! Rowan Audit should run clean
	run
	"Known issue with Rowan package structure ... will be addressed separately"
	true
		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
	System commit
%
	errorCount
  exit
```