### PR TITLE
v1.1.6 release

### DIFF
--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -25,6 +25,7 @@ set -e
 # 1.1.1 candidate 3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.1-candidate_3 v1.1.1-candidate_3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.3 v1.1.3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.4 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.4 v1.1.4 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.1.5 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.5 v1.1.5 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_410
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_410
@@ -1,0 +1,30 @@
+
+set -e
+
+rm -rf *.out
+
+GEMSTONE_NAME=$1
+export ROWAN_HOME="$(dirname $0)/../../../../"
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/install_issue_410.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+
+  set u SystemUser p swordfish
+  login
+! Rowan Audit should run clean
+	run
+	"Known issue with Rowan package structure ... will be addressed separately"
+	true
+		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
+	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
+		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
+	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
+	System commit
+%
+	errorCount
+  exit
+EOF
+

--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_410
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_410
@@ -9,7 +9,7 @@ export ROWAN_HOME="$(dirname $0)/../../../../"
 startTopaz $GEMSTONE_NAME -l << EOF
 
 	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
-  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/install_issue_410.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
 
   set u SystemUser p swordfish

--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_411
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_411
@@ -1,0 +1,30 @@
+
+set -e
+
+rm -rf *.out
+
+GEMSTONE_NAME=$1
+export ROWAN_HOME="$(dirname $0)/../../../../"
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+
+  set u SystemUser p swordfish
+  login
+! Rowan Audit should run clean
+	run
+	"Known issue with Rowan package structure ... will be addressed separately"
+	true
+		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
+	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
+		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
+	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
+	System commit
+%
+	errorCount
+  exit
+EOF
+

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_406.tpz
@@ -56,7 +56,9 @@ output push patch_issue_406.out
 		ar size = 1
 			ifTrue: [
 				| theProjectSetDefinition |
-				theProjectSetDefinition := readTool readProjectSetForProjectNamed: specification specName.
+				theProjectSetDefinition := readTool 
+					readProjectSetForProjectNamed: specification specName  
+					withGroupNames: #('core'  'tests' 'deprecated'). "skip reading jadeServer group, since JadeServer classes missing"
 				theProjectSetDefinition
 					do: [:projectDefinition |
 						projectSetDefinition addProject: projectDefinition ].
@@ -124,8 +126,14 @@ output push patch_issue_406.out
 		"mark projects and packages not dirty"
 		loadedProject markNotDirty.
 		loadedProject loadedPackages valuesDo: [:loadedPackage | loadedPackage markNotDirty ] ].
+
+	"Now reload Rowan including jadeServer group to get JadeServer classes properly installed"
+	Rowan projectTools load
+			loadProjectNamed: 'Rowan'
+			withGroupNames: #('core' 'tests' 'deprecated' 'jadeServer') 
 	
 %
+
   commit
 
 errorCount

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
@@ -1,0 +1,44 @@
+output push patch_issue_410.out
+
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit
+
+	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+
+  set user SystemUser p swordfish
+  login
+#---
+run
+  "update and load Rowan projects"
+  Rowan projectTools load
+    loadProjectNamed: 'Cypress';
+    loadProjectNamed: 'STON';
+    loadProjectNamed: 'Tonel';
+    loadProjectNamed: 'Rowan';
+    yourself
+%
+commit
+run
+    "If JadeServer classes are present, a simple reload of Rowan and 'jadeServer' group is not sufficient"
+    | jadeServerClass |
+    jadeServerClass := UserGlobals at: #JadeServer ifAbsent: [ ^ 'No JadeServer class found' ].
+		self error: 'Did not expected JadeServer class to be present'.
+%
+run
+    "For update from v1.0.2. Do the full load with the current list of group names ('jadeServer' being the most important"
+    Rowan projectTools load
+        loadProjectNamed: 'Rowan'
+        withConfigurations: #( 'Load' )
+        groupNames: #( 'core' 'tests' 'deprecated' 'jadeServer' )
+%
+commit
+#---
+
+errorCount
+
+  logout
+
+output pop
+
+

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
@@ -1,0 +1,61 @@
+output push patch_issue_410.out
+
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit
+
+	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+
+  set user SystemUser p swordfish
+  login
+
+#---
+
+run
+		| jadeServerClassNames |
+		jadeServerClassNames :=     {
+        'JadeServer64bit3x' .
+        'JadeServer' .
+        'JadeServer64bit24' .
+        'JadeServer64bit' .
+        'JadeServer64bit32' .
+    }.
+		"Disown the JadeServer classes ... methods are the ones we're after"
+		jadeServerClassNames do: [:className |
+        Rowan packageTools disown
+					disownClassNamed: className
+        ].
+    "Adopt the JadeServer classes into the Rowan-JadeServer package"
+		jadeServerClassNames do: [:className |
+        Rowan packageTools adopt
+            adoptClassNamed: className
+            intoPackageNamed: 'Rowan-JadeServer'
+        ].
+%
+
+run
+
+    "For update from v1.0.2. Do the full load with the current list of group names ('jadeServer' being the most important"
+    Rowan projectTools load
+        loadProjectNamed: 'Rowan'
+        withConfigurations: #( 'Load' )
+        groupNames: #( 'core' 'tests' 'deprecated' 'jadeServer' ).
+		Rowan projectTools load
+	    loadProjectNamed: 'Cypress';
+  	  loadProjectNamed: 'STON';
+    	loadProjectNamed: 'Tonel';
+    	yourself
+
+
+%
+
+commit
+
+#---
+errorCount
+
+  logout
+
+output pop
+
+


### PR DESCRIPTION
No modifications were made to the Rowan code base ... only supporting scripts for audit and patching have been changed/added.
### Bugfixes
1. Issue #410 - "v1.0.2 to v1.1.0 needs custom update load script"
1. Issue #411 - "repair script for repairing a case where JadeiteAlpha used with v1.1.0"
### Topaz patch script #410
```
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz

  set u SystemUser p swordfish
  login
! Rowan Audit should run clean
	run
	"Known issue with Rowan package structure ... will be addressed separately"
	true
		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
	System commit
%
	errorCount
  exit

```
### Topaz patch script #411 
```
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz

  set u SystemUser p swordfish
  login
! Rowan Audit should run clean
	run
	"Known issue with Rowan package structure ... will be addressed separately"
	true
		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
	System commit
%
	errorCount
  exit
```