### PR TITLE
v1.1.7 release

### DIFF
--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -26,6 +26,7 @@ set -e
 # 1.1.3 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.3 v1.1.3 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.4 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.4 v1.1.4 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 # 1.1.5 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.5 v1.1.5 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
+# 1.1.6 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.1.6 v1.1.6 Oscar-3.0.16 /export/gcm/where/gemstone64/releases/Edelweiss/sett/Sett1.0.zip
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"

--- a/platforms/gemstone/topaz/3.2.15/installRowan_issue_413
+++ b/platforms/gemstone/topaz/3.2.15/installRowan_issue_413
@@ -1,0 +1,30 @@
+
+set -e
+
+rm -rf *.out
+
+GEMSTONE_NAME=$1
+export ROWAN_HOME="$(dirname $0)/../../../../"
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_413.tpz
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
+
+  set u SystemUser p swordfish
+  login
+! Rowan Audit should run clean
+	run
+	"Known issue with Rowan package structure ... will be addressed separately"
+	true
+		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
+	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
+		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
+	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
+	System commit
+%
+	errorCount
+  exit
+EOF
+

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_410.tpz
@@ -4,8 +4,6 @@ output push patch_issue_410.out
   iferr 2 stack
   iferr 3 exit
 
-	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
-
   set user SystemUser p swordfish
   login
 #---

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_411.tpz
@@ -1,10 +1,8 @@
-output push patch_issue_410.out
+output push patch_issue_411.out
 
   iferr 1 stk
   iferr 2 stack
   iferr 3 exit
-
-	input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
 
   set user SystemUser p swordfish
   login

--- a/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_413.tpz
+++ b/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_413.tpz
@@ -1,0 +1,57 @@
+output push patch_issue_413.out
+
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit
+
+  set user SystemUser p swordfish
+  login
+#---
+run
+  "update and load Rowan projects"
+  Rowan projectTools load
+    loadProjectNamed: 'Cypress';
+    loadProjectNamed: 'STON';
+    loadProjectNamed: 'Tonel';
+    loadProjectNamed: 'Rowan';
+    yourself
+%
+commit
+run
+	"Outright remove JadeServer classes --- assume not packaged"
+	#(JadeServer64bit24
+		JadeServer64bit3x
+		JadeServer
+		JadeServer64bit32
+		JadeServer64bit )
+			do: [:className |
+				(UserGlobals at: className ifAbsent: [])
+					ifNotNil: [:aClass | 
+						| packageName |
+						packageName := aClass rowanProjectName.
+						packageName = '(NONE)'
+							ifFalse: [ 
+								self error: 'Did not expect ', className printString, ' to be packaged in  ', packageName printString ]. 
+						GsFile gciLogServer: 'Deleting ...', className, ' (', aClass asOop printString, ')'.
+						UserGlobals removeKey: className ]
+					ifNil: [
+						self error: 'Expected ', className printString, ' to be present' ] ].
+%
+	commit
+run
+    "For update from v1.0.2. Do the full load with the current list of group names ('jadeServer' being the most important"
+    Rowan projectTools load
+        loadProjectNamed: 'Rowan'
+        withConfigurations: #( 'Load' )
+        groupNames: #( 'core' 'tests' 'deprecated' 'jadeServer' )
+%
+commit
+#---
+
+errorCount
+
+  logout
+
+output pop
+
+


### PR DESCRIPTION
No modifications were made to the Rowan code base ... only supporting scripts for audit and patching have been changed/added.
### Bugfixes
1. Issue #413 - "v1.0.2 to v1.1.0 without `jadeSever` group, then use JadeiteAlpha2.0.1"
### Topaz patch script 
```
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/patch_Rowan_issue_413.tpz
  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/patches/audit_issue_365.tpz

  set u SystemUser p swordfish
  login
! Rowan Audit should run clean
	run
	"Known issue with Rowan package structure ... will be addressed separately"
	true
		ifTrue: [ (UserGlobals at: #ROWAN_AUDIT_issue_365_results) removeKey: 'RwUnmanagedProjectDefinition' ifAbsent: [] ].
	(UserGlobals at: #ROWAN_AUDIT_issue_365_results) isEmpty
		ifFalse: [ self error: 'Rowan Audit is not clean, please view dictionary ''UserGlobals at: #ROWAN_AUDIT_issue_399_results.out'' or log file for details.' ].
	UserGlobals removeKey: #ROWAN_AUDIT_issue_365_results ifAbsent: [].
	System commit
%
	errorCount
  exit

```