### PR TITLE
Issue 447 v1.2.x fix

### DIFF
--- a/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'Rowan' }
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> sessionAutomaticClassInitializationBlackList [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled.
+		Individual users may override the black list."
+
+	^ self platform automaticClassInitializationBlackList_session
+]

--- a/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
@@ -3,8 +3,17 @@ Extension { #name : 'Rowan' }
 { #category : '*rowan-gemstone-core' }
 Rowan class >> sessionAutomaticClassInitializationBlackList [
 
-	"Answer default list of project names for which automatic class initialiation should be disabled.
-		Individual users may override the black list."
+	"Answer session list of project names for which automatic class initialiation should be disabled.
+		Session black list only active for duration of GemStone session."
 
 	^ self platform automaticClassInitializationBlackList_session
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> userAutomaticClassInitializationBlackList [
+
+	"Answer user list of project names for which automatic class initialiation should be disabled.
+		user black list only applies to current user."
+
+	^ self platform automaticClassInitializationBlackList_user
 ]

--- a/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
@@ -112,6 +112,15 @@ RwGsPlatform >> clearAllPreferencesFor: preferenceSymbol [
 ]
 
 { #category : 'preferences' }
+RwGsPlatform >> clearDefaultPreferenceFor: preferenceSymbol [
+	"global preferences implements default preference"
+
+	self 
+		clearGlobalPreferenceFor: preferenceSymbol;
+		yourself
+]
+
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> clearGlobalPreferenceFor: preferenceSymbol [
 
 	self _globalPreferenceDict removeKey: preferenceSymbol ifAbsent: []
@@ -119,7 +128,7 @@ RwGsPlatform >> clearGlobalPreferenceFor: preferenceSymbol [
 
 { #category : 'preferences' }
 RwGsPlatform >> clearPreferenceFor: preferenceSymbol [
-
+	"clear sessoin and userPreferences - preserve non-gemstone semantics"
 
 	self 
 		clearSessionPreferenceFor: preferenceSymbol;
@@ -127,13 +136,13 @@ RwGsPlatform >> clearPreferenceFor: preferenceSymbol [
 		yourself
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> clearSessionPreferenceFor: preferenceSymbol [
 
 	self _sessionPreferenceDict removeKey: preferenceSymbol ifAbsent: []
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> clearUserPreferenceFor: preferenceSymbol [
 
 	self _userPreferenceDict removeKey: preferenceSymbol ifAbsent: []
@@ -162,7 +171,7 @@ RwGsPlatform >> globalNamed: aString [
 	^ Rowan image objectNamed: aString
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> globalPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _globalPreferenceDict 
@@ -239,7 +248,7 @@ RwGsPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
 						ifAbsent:aBlock ] ]
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> sessionPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _sessionPreferenceDict 
@@ -248,6 +257,14 @@ RwGsPlatform >> sessionPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 ]
 
 { #category : 'preferences' }
+RwGsPlatform >> setDefaultPreferenceFor: preferenceSymbol to: anObject [
+
+	"global preferences implements default preference"
+
+	^self setGlobalPreferenceFor: preferenceSymbol to: anObject
+]
+
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> setGlobalPreferenceFor: preferenceSymbol to: anObject [
 
 	self _globalPreferenceDict at: preferenceSymbol put: anObject
@@ -256,24 +273,25 @@ RwGsPlatform >> setGlobalPreferenceFor: preferenceSymbol to: anObject [
 { #category : 'preferences' }
 RwGsPlatform >> setPreferenceFor: preferenceSymbol to: anObject [
 
+	"clear session; set userPreferences - preserve non-gemstone semantics"
 
 	self clearSessionPreferenceFor: preferenceSymbol.
 	^self setUserPreferenceFor: preferenceSymbol to: anObject
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> setSessionPreferenceFor: preferenceSymbol to: anObject [
 
 	self _sessionPreferenceDict at: preferenceSymbol put: anObject
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> setUserPreferenceFor: preferenceSymbol to: anObject [
 
 	self _userPreferenceDict at: preferenceSymbol put: anObject
 ]
 
-{ #category : 'preferences' }
+{ #category : 'preferences - gemstone' }
 RwGsPlatform >> userPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _userPreferenceDict 

--- a/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
@@ -91,6 +91,22 @@ RwGsPlatform >> _userPreferenceDict [
 	^ self class _userPlatformDictionary at: #RwUserPlatform_Preferences ifAbsentPut: [ Dictionary new ]
 ]
 
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> automaticClassInitializationBlackList_session [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		sessionPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setSessionPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
 { #category : 'queries' }
 RwGsPlatform >> basePlatformAttribute [
 	"Answer the generic configuration attribute for the platform"
@@ -156,6 +172,14 @@ RwGsPlatform >> defaultConfiguration [
 		yourself
 ]
 
+{ #category : 'preferences' }
+RwGsPlatform >> defaultPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	"global preferences implements default preference"
+
+	^self globalPreferenceFor: preferenceSymbol ifAbsent: aBlock
+]
+
 { #category : 'queries' }
 RwGsPlatform >> fileUtilities [
   "Answer the platform-specific object for accessing files and directories"
@@ -176,7 +200,7 @@ RwGsPlatform >> globalPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _globalPreferenceDict 
 		at: preferenceSymbol 
-		ifAbSent: aBlock
+		ifAbsent: aBlock
 ]
 
 { #category : 'queries' }
@@ -253,7 +277,7 @@ RwGsPlatform >> sessionPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _sessionPreferenceDict 
 		at: preferenceSymbol 
-		ifAbSent: aBlock
+		ifAbsent: aBlock
 ]
 
 { #category : 'preferences' }
@@ -296,5 +320,5 @@ RwGsPlatform >> userPreferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self _userPreferenceDict 
 		at: preferenceSymbol 
-		ifAbSent: aBlock
+		ifAbsent: aBlock
 ]

--- a/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
@@ -26,6 +26,12 @@ RwGsPlatform >> _alternateImageClass: anImageClass [
 ]
 
 { #category : 'private' }
+RwGsPlatform >> _globalPreferenceDict [
+
+	^ (self class _userPlatformDictionaryForUser: 'SystemUser') at: #RwGlobalPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
+{ #category : 'private' }
 RwGsPlatform >> _parseMethod: source category: cat using: aSymbolList environmentId: anEnvironmentId [
 	"Compiles the method into disposable dictionaries, if possible.
 	 Attempts auto-recompile for undefinedSymbols.
@@ -73,6 +79,18 @@ RwGsPlatform >> _parseMethod: source category: cat using: aSymbolList environmen
 					with: [:ex | ex resume])
 ]
 
+{ #category : 'private' }
+RwGsPlatform >> _sessionPreferenceDict [
+
+	^ SessionTemps current at: #RwSessionPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
+{ #category : 'private' }
+RwGsPlatform >> _userPreferenceDict [
+
+	^ self class _userPlatformDictionary at: #RwUserPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
 { #category : 'queries' }
 RwGsPlatform >> basePlatformAttribute [
 	"Answer the generic configuration attribute for the platform"
@@ -80,6 +98,45 @@ RwGsPlatform >> basePlatformAttribute [
 
 	^ 'gemstone'
 
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearAllPreferencesFor: preferenceSymbol [
+
+
+	self 
+		clearSessionPreferenceFor: preferenceSymbol;
+		clearUserPreferenceFor: preferenceSymbol;
+		clearGlobalPreferenceFor: preferenceSymbol;
+		yourself
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearGlobalPreferenceFor: preferenceSymbol [
+
+	self _globalPreferenceDict removeKey: preferenceSymbol ifAbsent: []
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearPreferenceFor: preferenceSymbol [
+
+
+	self 
+		clearSessionPreferenceFor: preferenceSymbol;
+		clearUserPreferenceFor: preferenceSymbol;
+		yourself
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearSessionPreferenceFor: preferenceSymbol [
+
+	self _sessionPreferenceDict removeKey: preferenceSymbol ifAbsent: []
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearUserPreferenceFor: preferenceSymbol [
+
+	self _userPreferenceDict removeKey: preferenceSymbol ifAbsent: []
 ]
 
 { #category : 'defaults' }
@@ -103,6 +160,14 @@ RwGsPlatform >> globalNamed: aString [
 	"Answer a global object with the given name.  If no object with the given name is found, returns nil."
 
 	^ Rowan image objectNamed: aString
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> globalPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _globalPreferenceDict 
+		at: preferenceSymbol 
+		ifAbSent: aBlock
 ]
 
 { #category : 'queries' }
@@ -158,4 +223,60 @@ RwGsPlatform >> platformConfigurationAttributes [
 
 	^ super platformConfigurationAttributes, {self basePlatformAttribute. 'gemstone-kernel'. (System stoneVersionReport at: 'gsVersion') asRwGemStoneVersionNumber}
 
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _sessionPreferenceDict 
+		at: preferenceSymbol 
+		ifAbsent: [ 
+			self 
+				_userPreferenceDict at: preferenceSymbol 
+				ifAbsent: [
+					self _globalPreferenceDict 
+						at: preferenceSymbol
+						ifAbsent:aBlock ] ]
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> sessionPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _sessionPreferenceDict 
+		at: preferenceSymbol 
+		ifAbSent: aBlock
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setGlobalPreferenceFor: preferenceSymbol to: anObject [
+
+	self _globalPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setPreferenceFor: preferenceSymbol to: anObject [
+
+
+	self clearSessionPreferenceFor: preferenceSymbol.
+	^self setUserPreferenceFor: preferenceSymbol to: anObject
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setSessionPreferenceFor: preferenceSymbol to: anObject [
+
+	self _sessionPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setUserPreferenceFor: preferenceSymbol to: anObject [
+
+	self _userPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> userPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _userPreferenceDict 
+		at: preferenceSymbol 
+		ifAbSent: aBlock
 ]

--- a/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
@@ -104,7 +104,23 @@ RwGsPlatform >> automaticClassInitializationBlackList_session [
 			| list |
 			list := OrderedCollection new.
 			self setSessionPreferenceFor: preferenceSymbol to: list.
-			list]
+			list ]
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> automaticClassInitializationBlackList_user [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		userPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setUserPreferenceFor: preferenceSymbol to: list.
+			list ]
 ]
 
 { #category : 'queries' }
@@ -214,6 +230,7 @@ RwGsPlatform >> image [
 { #category : 'initialization' }
 RwGsPlatform >> initialize [
 
+	self automaticClassInitializationBlackList
 ]
 
 { #category : 'queries' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1212,7 +1212,8 @@ RwGsPatchSet_254 >> runInitializers [
 
 	"run the class initialization methods as needed"
 
-	| methodPatches orderedMethodPatches |
+	| methodPatches orderedMethodPatches blackList |
+	blackList := Rowan automaticClassInitializationBlackList.
 	methodPatches := (addedMethods copy
 		addAll: extendedMethods;
 		addAll: methodsNeedingRecompile;
@@ -1222,10 +1223,11 @@ RwGsPatchSet_254 >> runInitializers [
 		ifTrue: [ self class methodPatchesInInitializationOrder: methodPatches ]
 		ifFalse: [ methodPatches ].
 	orderedMethodPatches do: [ :methodPatch | 
-			(RwExecuteClassInitializeMethodsAfterLoadNotification new
-				candidateClass: methodPatch behavior thisClass) signal 
-					ifTrue: [ methodPatch runInitializer ] ]
-
+		(blackList includes: methodPatch projectDefinition name)
+			ifFalse: [ 
+				(RwExecuteClassInitializeMethodsAfterLoadNotification new
+					candidateClass: methodPatch behavior thisClass) signal 
+						ifTrue: [ methodPatch runInitializer ] ] ]
 ]
 
 { #category : 'private - applying' }

--- a/rowan/src/Rowan-JadeServer/JadeServer.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer.class.st
@@ -1037,7 +1037,10 @@ JadeServer >> compile: aString frame: anInteger process: aGsProcess [
 	category := self _behavior: aBehavior categoryOfSelector: selector.
 	result := ((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile
 				ifAbsent: [false])
-					ifTrue: [aBehavior rwCompileMethod: aString category: category]
+					ifTrue: [ 
+						[ aBehavior rwCompileMethod: aString category: category ]
+							on: RwExecuteClassInitializeMethodsAfterLoadNotification
+							do: [:ex | ex resume: false ] ]
 					ifFalse: 
 						[self
 							compileMethod: aString
@@ -1045,7 +1048,6 @@ JadeServer >> compile: aString frame: anInteger process: aGsProcess [
 							user: nil
 							inCategory: category].
 	^result
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer64bit.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer64bit.class.st
@@ -145,15 +145,16 @@ JadeServer64bit >> recompile: aMethod withSource: aString [
 	behavior := aMethod inClass.
 	((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile ifAbsent: [false])
 		ifTrue: 
-			[behavior rwCompileMethod: aString
-				category: (self _behavior: behavior categoryOfSelector: aMethod selector).
+			[ [ behavior rwCompileMethod: aString
+				category: (self _behavior: behavior categoryOfSelector: aMethod selector) ]
+					on: RwExecuteClassInitializeMethodsAfterLoadNotification
+					do: [:ex | ex resume: false ].
 			Rowan serviceClass rowanFixMe.	"need to handle compile errors"
 			^true]
 		ifFalse: 
 			[result := aMethod _recompileWithSource: aString.
 			result isNil ifTrue: [^true].	"Bug 41195 returns nil if success so assume it is the same method"
 			^result]
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
@@ -140,7 +140,9 @@ JadeServer64bit3x >> compileMethod: methodString behavior: aBehavior symbolList:
 	| method warnings | 
 
 	[[((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile ifAbsent:[false]) ifTrue:[
-			method := aBehavior rwCompileMethod: methodString category: categorySymbol]
+			[ method := aBehavior rwCompileMethod: methodString category: categorySymbol ]
+					on: RwExecuteClassInitializeMethodsAfterLoadNotification
+					do: [:ex | ex resume: false ] ]
 		ifFalse:[
 			method := aBehavior
 			compileMethod: methodString
@@ -158,8 +160,6 @@ JadeServer64bit3x >> compileMethod: methodString behavior: aBehavior symbolList:
 	] on: Error do: [:ex | 
 		ex return: method -> warnings.
 	].
-
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-Kernel/Rowan.class.st
+++ b/rowan/src/Rowan-Kernel/Rowan.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : 'Rowan-Kernel'
 }
 
+{ #category : 'public' }
+Rowan class >> automaticClassInitializationBlackList [
+
+	"Answer list of project names for which automatic class initialiation should be disabled."
+
+	^ self platform automaticClassInitializationBlackList
+]
+
 { #category : 'public client services' }
 Rowan class >> classServiceClass [
 
@@ -24,6 +32,15 @@ Rowan class >> classServiceClass [
 Rowan class >> configuration [
 
 	^configuration
+]
+
+{ #category : 'public' }
+Rowan class >> defaultAutomaticClassInitializationBlackList [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled.
+		Individual users may override the black list."
+
+	^ self platform automaticClassInitializationBlackList_default
 ]
 
 { #category : 'private' }

--- a/rowan/src/Rowan-Kernel/RwPlatform.class.st
+++ b/rowan/src/Rowan-Kernel/RwPlatform.class.st
@@ -8,6 +8,44 @@ Class {
 	#category : 'Rowan-Kernel'
 }
 
+{ #category : 'automatic class initialization' }
+RwPlatform >> _automaticClassInitializationBlackList_symbol [
+
+	^#automaticClassInitializationBlackList
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> automaticClassInitializationBlackList [
+
+	"Answer list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		preferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> automaticClassInitializationBlackList_default [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		defaultPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setDefaultPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
 { #category : 'queries' }
 RwPlatform >> basePlatformAttribute [
 	"Answer the generic configuration attribute for the platform"
@@ -35,6 +73,18 @@ RwPlatform >> clearDefaultPreferenceFor: preferenceSymbol [
 RwPlatform >> clearPreferenceFor: preferenceSymbol [ 
 
 	self subclassResponisbility: #clearPreferenceFor:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> defaultPreferenceFor: preferenceSymbol [
+
+	^ self defaultPreferenceFor: preferenceSymbol ifAbsent: [ self error: 'No preference found for ', preferenceSymbol asString printString ]
+]
+
+{ #category : 'preferences' }
+RwPlatform >> defaultPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self subclassResponisbility: #defaultPreferenceFor:ifAbsent:
 ]
 
 { #category : 'queries' }

--- a/rowan/src/Rowan-Kernel/RwPlatform.class.st
+++ b/rowan/src/Rowan-Kernel/RwPlatform.class.st
@@ -19,6 +19,18 @@ RwPlatform >> basePlatformAttribute [
 
 ]
 
+{ #category : 'preferences' }
+RwPlatform >> clearAllPreferencesFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearAllPreferencesFor:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> clearPreferenceFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearPreferenceFor:
+]
+
 { #category : 'queries' }
 RwPlatform >> fileUtilities [
 	"Answer the platform-specific object for accessing files and directories"
@@ -51,6 +63,24 @@ RwPlatform >> platformConfigurationAttributes [
 
 	^ #('common')
 
+]
+
+{ #category : 'preferences' }
+RwPlatform >> preferenceFor: preferenceSymbol [
+
+	^ self preferenceFor: preferenceSymbol ifAbsent: [ self error: 'No preference found for ', preferenceSymbol asString printString ]
+]
+
+{ #category : 'preferences' }
+RwPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self subclassResponisbility: #preferenceFor:ifAbsent:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> setPreferenceFor: preferenceSymbol to: anObject [
+
+	self subclassResponisbility: #setPreferenceFor:to:
 ]
 
 { #category : 'queries' }

--- a/rowan/src/Rowan-Kernel/RwPlatform.class.st
+++ b/rowan/src/Rowan-Kernel/RwPlatform.class.st
@@ -26,6 +26,12 @@ RwPlatform >> clearAllPreferencesFor: preferenceSymbol [
 ]
 
 { #category : 'preferences' }
+RwPlatform >> clearDefaultPreferenceFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearDefaultPreferenceFor:
+]
+
+{ #category : 'preferences' }
 RwPlatform >> clearPreferenceFor: preferenceSymbol [ 
 
 	self subclassResponisbility: #clearPreferenceFor:
@@ -75,6 +81,12 @@ RwPlatform >> preferenceFor: preferenceSymbol [
 RwPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
 
 	^ self subclassResponisbility: #preferenceFor:ifAbsent:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> setDefaultPreferenceFor: preferenceSymbol to: anObject [
+
+	self subclassResponisbility: #setDefaultPreferenceFor:to:
 ]
 
 { #category : 'preferences' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -261,13 +261,16 @@ RowanClassService >> compileMethod: methodString behavior: aBehavior symbolList:
 
 	| method warnings |
 	
-	[[method := aBehavior rwCompileMethod: methodString category: categorySymbol] on: CompileError
-		do: [:ex | ^nil -> (ex gsArguments at: 1)]]
-			on: CompileWarning
-			do: 
-				[:ex | 
-				warnings := ex warningString.
-				ex resume].
+	[ [ [ method := aBehavior rwCompileMethod: methodString category: categorySymbol  ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | ex resume: false ] ] 
+			on: CompileError
+			do: [:ex | ^nil -> (ex gsArguments at: 1)]]
+				on: CompileWarning
+				do: 
+					[:ex | 
+					warnings := ex warningString.
+					ex resume].
 	^[(self compiledMethodAt: method key selector inClass: aBehavior) -> warnings] on: Error
 		do: [:ex | ex return: method -> warnings]
 ]

--- a/rowan/src/Rowan-Tests/RwEditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwEditToolTest.class.st
@@ -1,6 +1,11 @@
 Class {
 	#name : 'RwEditToolTest',
 	#superclass : 'RwToolTest',
+	#instVars : [
+		'globalBlackList',
+		'userBlackList',
+		'sessionBlackList'
+	],
 	#category : 'Rowan-Tests'
 }
 
@@ -199,11 +204,51 @@ RwEditToolTest >> _standardProjectDefinition: projectName packageNames: packageN
 ]
 
 { #category : 'running' }
+RwEditToolTest >> setUp [
+
+	| preferenceSymbol |
+	super setUp.
+
+"get current black list values"
+	preferenceSymbol := Rowan platform _automaticClassInitializationBlackList_symbol.
+	globalBlackList :=	(Rowan platform 
+		globalPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+	userBlackList :=	(Rowan platform 
+		userPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+	sessionBlackList :=	(Rowan platform 
+		sessionPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+]
+
+{ #category : 'running' }
 RwEditToolTest >> tearDown [
+
+	| preferenceSymbol |
 
 	super tearDown.
 
-	Rowan sessionAutomaticClassInitializationBlackList remove: 'Simple' ifAbsent: [].	"clean up blackList"
+"clean up blackList"
+	preferenceSymbol := Rowan platform _automaticClassInitializationBlackList_symbol.
+	globalBlackList
+		ifNil: [ Rowan platform clearGlobalPreferenceFor: preferenceSymbol ]
+		ifNotNil: [
+			Rowan platform 
+				setGlobalPreferenceFor: preferenceSymbol 
+				to: globalBlackList ].
+	userBlackList
+		ifNil: [ Rowan platform clearUserPreferenceFor: preferenceSymbol ]
+		ifNotNil: [
+			Rowan platform 
+				setUserPreferenceFor: preferenceSymbol 
+				to: userBlackList ].
+	sessionBlackList
+		ifNil: [ Rowan platform clearSessionPreferenceFor: preferenceSymbol ]
+		ifNotNil: [
+			Rowan platform 
+				setSessionPreferenceFor: preferenceSymbol 
+				to: sessionBlackList ].
 ]
 
 { #category : 'tests - classes' }
@@ -262,11 +307,11 @@ RwEditToolTest >> testAddAndRemoveClass [
 ]
 
 { #category : 'tests - classes' }
-RwEditToolTest >> testAddClass_blackList [
+RwEditToolTest >> testAddClass_blackList_A [
 
 	"https://github.com/GemTalk/Rowan/issues/447"
 
-	"test that blackList is used to block class initialization"
+	"test that blackList is used to block class initialization - sessionAutomaticClassInitializationBlackList"
 
 	| projectName projectDefinition projectTools packageNames classDefinition packageName testClass testInstance className |
 	projectName := 'Simple'.
@@ -297,6 +342,57 @@ RwEditToolTest >> testAddClass_blackList [
 
 "add project to session blackList"
 	Rowan sessionAutomaticClassInitializationBlackList add: projectName.
+
+"load project - initialization should not be triggered"
+	[ projectTools load loadProjectDefinition: projectDefinition ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | self assert: false description: 'unexpected signal of RwExecuteClassInitializeMethodsAfterLoadNotification'  ].
+
+"validate"
+	testClass := Rowan globalNamed: className.
+	self assert: testClass notNil.
+	self assert: testClass civar1 isNil.
+	self assert: testClass cvar1 isNil.
+	testInstance := testClass new.
+	self assert: testInstance ivar1 isNil.
+]
+
+{ #category : 'tests - classes' }
+RwEditToolTest >> testAddClass_blackList_B [
+
+	"https://github.com/GemTalk/Rowan/issues/447"
+
+	"test that blackList is used to block class initialization - userAutomaticClassInitializationBlackList"
+
+	| projectName projectDefinition projectTools packageNames classDefinition packageName testClass testInstance className |
+	projectName := 'Simple'.
+	packageName := 'Simple-Core'.
+	packageNames := {packageName}.
+	projectTools := Rowan projectTools.
+
+	{projectName}
+		do: [ :name | 
+			(Rowan image loadedProjectNamed: name ifAbsent: [  ])
+				ifNotNil: [ :project | Rowan image _removeLoadedProject: project ] ].
+
+"create project definition"
+	projectDefinition := self
+		_standardProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment:
+			'Testing class initialization blackList'.
+
+	className := 'SimpleEdit'.
+	classDefinition := self _standardClassDefinition: className.
+
+	projectTools edit
+		addClass: classDefinition
+		inPackageNamed: packageName
+		inProject: projectDefinition.
+
+"add project to user blackList"
+	Rowan userAutomaticClassInitializationBlackList add: projectName.
 
 "load project - initialization should not be triggered"
 	[ projectTools load loadProjectDefinition: projectDefinition ]

--- a/rowan/src/Rowan-Tests/RwEditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwEditToolTest.class.st
@@ -198,6 +198,14 @@ RwEditToolTest >> _standardProjectDefinition: projectName packageNames: packageN
 
 ]
 
+{ #category : 'running' }
+RwEditToolTest >> tearDown [
+
+	super tearDown.
+
+	Rowan sessionAutomaticClassInitializationBlackList remove: 'Simple' ifAbsent: [].	"clean up blackList"
+]
+
 { #category : 'tests - classes' }
 RwEditToolTest >> testAddAndRemoveClass [
 
@@ -251,6 +259,57 @@ RwEditToolTest >> testAddAndRemoveClass [
 	testClass := Rowan globalNamed: className.
 	self assert: testClass isNil
 
+]
+
+{ #category : 'tests - classes' }
+RwEditToolTest >> testAddClass_blackList [
+
+	"https://github.com/GemTalk/Rowan/issues/447"
+
+	"test that blackList is used to block class initialization"
+
+	| projectName projectDefinition projectTools packageNames classDefinition packageName testClass testInstance className |
+	projectName := 'Simple'.
+	packageName := 'Simple-Core'.
+	packageNames := {packageName}.
+	projectTools := Rowan projectTools.
+
+	{projectName}
+		do: [ :name | 
+			(Rowan image loadedProjectNamed: name ifAbsent: [  ])
+				ifNotNil: [ :project | Rowan image _removeLoadedProject: project ] ].
+
+"create project definition"
+	projectDefinition := self
+		_standardProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment:
+			'Testing class initialization blackList'.
+
+	className := 'SimpleEdit'.
+	classDefinition := self _standardClassDefinition: className.
+
+	projectTools edit
+		addClass: classDefinition
+		inPackageNamed: packageName
+		inProject: projectDefinition.
+
+"add project to session blackList"
+	Rowan sessionAutomaticClassInitializationBlackList add: projectName.
+
+"load project - initialization should not be triggered"
+	[ projectTools load loadProjectDefinition: projectDefinition ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | self assert: false description: 'unexpected signal of RwExecuteClassInitializeMethodsAfterLoadNotification'  ].
+
+"validate"
+	testClass := Rowan globalNamed: className.
+	self assert: testClass notNil.
+	self assert: testClass civar1 isNil.
+	self assert: testClass cvar1 isNil.
+	testInstance := testClass new.
+	self assert: testInstance ivar1 isNil.
 ]
 
 { #category : 'tests - classes' }

--- a/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
+++ b/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
@@ -32,6 +32,13 @@ RwPlatformInstanceTest >> testDefaultPrecedence [
 	platformInstance setPreferenceFor: preference to: #user.
 	self assert: (x := platformInstance preferenceFor: preference) == #user. 
 
+	self assert: (x := platformInstance defaultPreferenceFor: preference) == #default. 
+
+"testing GemStone implementation"
+	self assert: (x := platformInstance  globalPreferenceFor: preference ifAbsent: [#absent ]) == #default. 
+	self assert: (x := platformInstance  userPreferenceFor: preference ifAbsent: [#absent ]) == #user. 
+	self assert: (x := platformInstance  sessionPreferenceFor: preference ifAbsent: [ #absent ]) == #absent. 
+
 	platformInstance clearPreferenceFor: preference.
 	platformInstance clearDefaultPreferenceFor: preference.
 	self should: [ platformInstance preferenceFor: preference ] raise: Error
@@ -72,7 +79,10 @@ RwPlatformInstanceTest >> testPreferencePrecedence [
 	self assert: (platformInstance preferenceFor: preference) == #session.
 
 	platformInstance setPreferenceFor: preference to: #default.
-	self assert: (x := platformInstance preferenceFor: preference) == #default. 	"session prefs cleared and user prefs set"
+	self assert: (x := platformInstance preferenceFor: preference) == #default. 
+
+	self assert: (x := platformInstance userPreferenceFor: preference ifAbsent: [ #absent ]) == #default. 		"session prefs cleared and user prefs set"
+	self assert: (x := platformInstance sessionPreferenceFor: preference ifAbsent: [ #absent ]) == #absent. 	"session prefs cleared and user prefs set"
 
 	platformInstance setSessionPreferenceFor: preference to: #session.
 	platformInstance clearPreferenceFor: preference.										"session and user prefs cleared"

--- a/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
+++ b/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
@@ -18,6 +18,26 @@ RwPlatformInstanceTest >> tearDown [
 ]
 
 { #category : 'tests' }
+RwPlatformInstanceTest >> testDefaultPrecedence [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance setDefaultPreferenceFor: preference to: #default.
+	self assert: (platformInstance preferenceFor: preference) == #default.
+
+	platformInstance setPreferenceFor: preference to: #user.
+	self assert: (x := platformInstance preferenceFor: preference) == #user. 
+
+	platformInstance clearPreferenceFor: preference.
+	platformInstance clearDefaultPreferenceFor: preference.
+	self should: [ platformInstance preferenceFor: preference ] raise: Error
+]
+
+{ #category : 'tests' }
 RwPlatformInstanceTest >> testGlobalPreferences [
 
 	"https://github.com/GemTalk/Rowan/issues/448"

--- a/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
+++ b/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
@@ -17,7 +17,7 @@ RwPlatformInstanceTest >> tearDown [
 	Rowan platform clearAllPreferencesFor: self _testPreference
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testDefaultPrecedence [
 
 	"https://github.com/GemTalk/Rowan/issues/448"
@@ -37,7 +37,7 @@ RwPlatformInstanceTest >> testDefaultPrecedence [
 	self should: [ platformInstance preferenceFor: preference ] raise: Error
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testGlobalPreferences [
 
 	"https://github.com/GemTalk/Rowan/issues/448"
@@ -53,7 +53,7 @@ RwPlatformInstanceTest >> testGlobalPreferences [
 	self assert: (platformInstance preferenceFor: preference).
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testPreferencePrecedence [
 
 	"https://github.com/GemTalk/Rowan/issues/448"
@@ -79,7 +79,7 @@ RwPlatformInstanceTest >> testPreferencePrecedence [
 	self assert: (x := platformInstance preferenceFor: preference) == #global.
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testPreferences [
 
 	"https://github.com/GemTalk/Rowan/issues/448"
@@ -97,7 +97,7 @@ RwPlatformInstanceTest >> testPreferences [
 	self assert: (platformInstance preferenceFor: preference).
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testSessionPreferences [
 
 	"https://github.com/GemTalk/Rowan/issues/448"
@@ -113,7 +113,7 @@ RwPlatformInstanceTest >> testSessionPreferences [
 	self assert: (platformInstance preferenceFor: preference).
 ]
 
-{ #category : 'tests' }
+{ #category : 'test preferences (issue #448)' }
 RwPlatformInstanceTest >> testUserPreferences [
 
 	"https://github.com/GemTalk/Rowan/issues/448"

--- a/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
+++ b/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
@@ -1,0 +1,110 @@
+Class {
+	#name : 'RwPlatformInstanceTest',
+	#superclass : 'RwToolTest',
+	#category : 'Rowan-Tests'
+}
+
+{ #category : 'private' }
+RwPlatformInstanceTest >> _testPreference [
+
+	^#'unknown_preference'
+]
+
+{ #category : 'running' }
+RwPlatformInstanceTest >> tearDown [
+
+	super tearDown.
+	Rowan platform clearAllPreferencesFor: self _testPreference
+]
+
+{ #category : 'tests' }
+RwPlatformInstanceTest >> testGlobalPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearGlobalPreferenceFor: preference.
+	self should: [ x := platformInstance globalPreferenceFor: preference ] raise: Error.
+
+	platformInstance setGlobalPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'tests' }
+RwPlatformInstanceTest >> testPreferencePrecedence [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance setGlobalPreferenceFor: preference to: #global.
+	self assert: (platformInstance preferenceFor: preference) == #global.
+
+	platformInstance setUserPreferenceFor: preference to: #user.
+	self assert: (platformInstance preferenceFor: preference) == #user.
+
+	platformInstance setSessionPreferenceFor: preference to: #session.
+	self assert: (platformInstance preferenceFor: preference) == #session.
+
+	platformInstance setPreferenceFor: preference to: #default.
+	self assert: (x := platformInstance preferenceFor: preference) == #default. 	"session prefs cleared and user prefs set"
+
+	platformInstance setSessionPreferenceFor: preference to: #session.
+	platformInstance clearPreferenceFor: preference.										"session and user prefs cleared"
+	self assert: (x := platformInstance preferenceFor: preference) == #global.
+]
+
+{ #category : 'tests' }
+RwPlatformInstanceTest >> testPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	self assert: (platformInstance isKindOf: RwPlatform).
+
+	platformInstance clearPreferenceFor: preference.
+	self should: [ x := platformInstance preferenceFor: preference ] raise: Error.
+
+	platformInstance setPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'tests' }
+RwPlatformInstanceTest >> testSessionPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearSessionPreferenceFor: preference.
+	self should: [ x := platformInstance sessionPreferenceFor: preference ] raise: Error.
+
+	platformInstance setSessionPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'tests' }
+RwPlatformInstanceTest >> testUserPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearUserPreferenceFor: preference.
+	self should: [ x := platformInstance userPreferenceFor: preference ] raise: Error.
+
+	platformInstance setUserPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -1754,7 +1754,6 @@ RwRowanSample4Test >> testIssue305 [
 		loadProjectFromSpecUrl: 'file:' , repoRootPath, '/rowan/specs/RowanSample4_core.ston'.
 
 	self assert: (Rowan globalNamed: 'RowanSample4Test') isNil.
-
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
v1.2.x portion of fix for Issue #447 and Issue #448:
- [x] Blacklist of projects not wanting automatic class initialization is the short term solution (07db1fb)
- [x] #initialize method should never be automatically run in Jadeite, regardless of the black-list setting (824e03f)

### API (see `RwEditToolTest>>testPreferences`)
```smalltalk
"add project to automatic class initialization black list"
Rowan automaticClassInitializationBlackList 
  add: projectName.

"remove project from automatic class initialization black list"
Rowan automaticClassInitializationBlackList 
  remove: projectName
   ifAbsent: [].

"clear automatic class initialization black list"
Rowan clearAutomaticClassInitializationBlackList.

"add project to global automatic class initialization black list"
Rowan glogalAutomaticClassInitializationBlackList 
  add: projectName.

"clear global automatic class initialization black list"
Rowan clearGlobalAutomaticClassInitializationBlackList.

"add project to user automatic class initialization black list"
Rowan userAutomaticClassInitializationBlackList 
  add: projectName.

"clear user automatic class initialization black list"
Rowan clearUserAutomaticClassInitializationBlackList.

"add project to session automatic class initialization black list"
Rowan sessionAutomaticClassInitializationBlackList 
  add: projectName.

"clear session automatic class initialization black list"
Rowan clearSessionAutomaticClassInitializationBlackList.

```