### PR TITLE
v1.2.6 release

### DIFF
--- a/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressError.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressError.class.st
@@ -4,6 +4,5 @@ All Cypress classes are private to GemStone and are likely to be removed in a fu
 Class {
 	#name : 'CypressError',
 	#superclass : 'Error',
-	#type : 'variable',
 	#category : 'Cypress-Definitions'
 }

--- a/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderError.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderError.class.st
@@ -16,7 +16,6 @@ exception:			the Error which occurred while trying to apply the Patch Operation.
 Class {
 	#name : 'CypressLoaderError',
 	#superclass : 'Error',
-	#type : 'variable',
 	#instVars : [
 		'exception',
 		'patchOperation'

--- a/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderErrorNotification.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderErrorNotification.class.st
@@ -14,7 +14,6 @@ exception:			the Error which occurred while trying to apply the Patch Operation.
 Class {
 	#name : 'CypressLoaderErrorNotification',
 	#superclass : 'Notification',
-	#type : 'variable',
 	#instVars : [
 		'exception',
 		'patchOperation'

--- a/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderMissingClasses.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-Definitions/CypressLoaderMissingClasses.class.st
@@ -4,7 +4,6 @@ All Cypress classes are private to GemStone and are likely to be removed in a fu
 Class {
 	#name : 'CypressLoaderMissingClasses',
 	#superclass : 'Error',
-	#type : 'variable',
 	#instVars : [
 		'requirementsMap'
 	],

--- a/platforms/gemstone/projects/cypress/src/Cypress-GemStoneFileServer/CypressGemStoneDirectoryUtilities.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-GemStoneFileServer/CypressGemStoneDirectoryUtilities.class.st
@@ -57,8 +57,8 @@ CypressGemStoneDirectoryUtilities class >> directoryEntriesFrom: aDirectory [
 { #category : 'utilities' }
 CypressGemStoneDirectoryUtilities class >> directoryExists: aDirectory [
 
-	^GsFile existsOnServer: aDirectory
-
+	"handle the case where GsFile class>>existsOnServer: returns nil"
+	^ (GsFile existsOnServer: aDirectory) == true
 ]
 
 { #category : 'utilities' }
@@ -135,13 +135,12 @@ CypressGemStoneDirectoryUtilities class >> endsWithSpecial: filename [
 CypressGemStoneDirectoryUtilities class >> ensureDirectoryExists: aDirectory [
 
 	| lastSeparator |
-	(GsFile existsOnServer: aDirectory) ifTrue: [^aDirectory].
+	(GsFile existsOnServer: aDirectory) == true ifTrue: [^aDirectory].
 	(GsFile createServerDirectory: aDirectory) ifNotNil: [^aDirectory].
 	lastSeparator := aDirectory findLastSubString: self pathNameDelimiter startingAt: aDirectory size.
 	lastSeparator <= 1 ifTrue: [self error: 'Cannot create directory'].
 	self ensureDirectoryExists: (aDirectory copyFrom: 1 to: lastSeparator - 1).
 	self ensureDirectoryExists: aDirectory.
-
 ]
 
 { #category : 'initializating' }

--- a/platforms/gemstone/projects/cypress/src/Cypress-MesssageDigest/CypressClassStructure.extension.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-MesssageDigest/CypressClassStructure.extension.st
@@ -63,4 +63,5 @@ CypressClassStructure >> isSkeleton [
 		and: [classMethods isNil
 		and: [comment isNil
 		and: [isClassExtension isNil]]]
+
 ]

--- a/platforms/gemstone/projects/cypress/src/Cypress-Structure/CypressJsonError.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-Structure/CypressJsonError.class.st
@@ -4,6 +4,5 @@ All Cypress classes are private to GemStone and are likely to be removed in a fu
 Class {
 	#name : 'CypressJsonError',
 	#superclass : 'Error',
-	#type : 'variable',
 	#category : 'Cypress-Structure'
 }

--- a/platforms/gemstone/topaz/3.2.15/cypress/Cypress-GemStoneFileServer.gs
+++ b/platforms/gemstone/topaz/3.2.15/cypress/Cypress-GemStoneFileServer.gs
@@ -1867,7 +1867,8 @@ category: 'utilities'
 classmethod: CypressGemStoneDirectoryUtilities
 directoryExists: aDirectory
 
-	^GsFile existsOnServer: aDirectory
+       "handle the case where GsFile class>>existsOnServer: returns nil"
+       ^ (GsFile existsOnServer: aDirectory) == true
 %
 
 category: 'utilities'
@@ -1945,7 +1946,7 @@ classmethod: CypressGemStoneDirectoryUtilities
 ensureDirectoryExists: aDirectory
 
 	| lastSeparator |
-	(GsFile existsOnServer: aDirectory) ifTrue: [^aDirectory].
+	(GsFile existsOnServer: aDirectory) == true ifTrue: [^aDirectory].
 	(GsFile createServerDirectory: aDirectory) ifNotNil: [^aDirectory].
 	lastSeparator := aDirectory findLastSubString: self pathNameDelimiter startingAt: aDirectory size.
 	lastSeparator <= 1 ifTrue: [self error: 'Cannot create directory'].

--- a/platforms/gemstone/topaz/3.2.15/cypress/bootstrapCypressSupport.topaz
+++ b/platforms/gemstone/topaz/3.2.15/cypress/bootstrapCypressSupport.topaz
@@ -17,6 +17,11 @@
 
 output push cypress.out
 
+	run
+	(System myUserProfile objectNamed: 'Rowan')
+		ifNotNil: [ self error: 'Rowan is already installed!' ].
+%
+
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/cypress/Cypress-Definitions.gs
 errorCount
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/cypress/Cypress-Structure.gs

--- a/platforms/gemstone/topaz/3.2.15/install.tpz
+++ b/platforms/gemstone/topaz/3.2.15/install.tpz
@@ -6,6 +6,11 @@
   set u SystemUser p swordfish
   login
 
+	run
+	(System myUserProfile objectNamed: 'Rowan')
+		ifNotNil: [ self error: 'Rowan is already installed!' ].
+%
+
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/cypress/bootstrapCypressSupport.topaz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/ston/bootstrapStonSupport.topaz
   input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/tonel/bootstrapTonelSupport.topaz

--- a/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
+++ b/platforms/gemstone/topaz/3.2.15/rowan/Rowan-Bootstrap.gs
@@ -1,6 +1,11 @@
   set u SystemUser p swordfish
   login
 
+	run
+	(System myUserProfile objectNamed: 'Rowan')
+		ifNotNil: [ self error: 'Rowan is already installed!' ].
+%
+
 # set rowanCompile to true 
 #
   run

--- a/platforms/gemstone/topaz/3.2.15/ston/bootstrapStonSupport.topaz
+++ b/platforms/gemstone/topaz/3.2.15/ston/bootstrapStonSupport.topaz
@@ -4,6 +4,11 @@
 
 output push ston.out
 
+	run
+	(System myUserProfile objectNamed: 'Rowan')
+		ifNotNil: [ self error: 'Rowan is already installed!' ].
+%
+
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/ston/STON-Core.gs
 errorCount
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/ston/STON-GemStoneBase-Core.gs

--- a/platforms/gemstone/topaz/3.2.15/tonel/bootstrapTonelSupport.topaz
+++ b/platforms/gemstone/topaz/3.2.15/tonel/bootstrapTonelSupport.topaz
@@ -4,6 +4,11 @@
 
 output push tonel.out
 
+	run
+	(System myUserProfile objectNamed: 'Rowan')
+		ifNotNil: [ self error: 'Rowan is already installed!' ].
+%
+
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/tonel/Tonel-Core.gs
 errorCount
 input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/tonel/Tonel-GemStoneCommon-Core.gs

--- a/platforms/gemstone/topaz/rowanTestSuite.gs
+++ b/platforms/gemstone/topaz/rowanTestSuite.gs
@@ -14,6 +14,9 @@ run
 			Rowan projectTools load
 				loadProjectNamed: projectName
 				withGroupNames: #('tests' 'deprecated' 'jadeServer') ].
+
+		System commit. "do a commit immediately after test code is loaded, to avoid losing test classes if a test does an apport"
+
 		"audit after load"
 		projectNames do: [:projectName |
 			| audit |

--- a/rowan/specs/Rowan.ston
+++ b/rowan/specs/Rowan.ston
@@ -1,7 +1,7 @@
  RwSimpleProjectSpecification{
 	#specName : 'Rowan',
 	#version : '0.2.0',
-	#projectUrl : 'https://github.com/dalehenrich/Rowan',
+	#projectUrl : 'https://github.com/GemTalk/Rowan',
 	#repoSpec : RwGitRepositorySpecification {
 		#committish : 'master',
 		#committishType : 'branch'

--- a/rowan/src/Rowan-Core-Definitions-Extensions/RwProjectDefinition.extension.st
+++ b/rowan/src/Rowan-Core-Definitions-Extensions/RwProjectDefinition.extension.st
@@ -31,5 +31,5 @@ RwProjectDefinition >> compareAgainstBase: aDefinition [
 { #category : '*rowan-core-definitions-extensions' }
 RwProjectDefinition >> projectDefinitionSourceProperty [
 
-	^ properties at: RwLoadedProject _projectDefinitionSourceKey ifAbsent: [ 'unknown' ]
+	^ properties at: RwLoadedProject _projectDefinitionSourceKey ifAbsent: [ RwLoadedProject _projectUnknownDefinitionSourceValue ]
 ]

--- a/rowan/src/Rowan-Core-Definitions-Extensions/RwProjectDefinition.extension.st
+++ b/rowan/src/Rowan-Core-Definitions-Extensions/RwProjectDefinition.extension.st
@@ -1,6 +1,17 @@
 Extension { #name : 'RwProjectDefinition' }
 
 { #category : '*rowan-core-definitions-extensions' }
+RwProjectDefinition >> _compareProperty: propertyKey propertyVaue: propertyValue againstBaseValue: baseValue [
+
+	({ 'spec'. RwLoadedProject _projectDefinitionSourceKey } includes: propertyKey)
+		ifTrue: [ 
+		"spec entries are considered to be equal for comparison purposes"
+		"_projectDefinitionSourceKey entries are considered equal for comparison purpposes"
+		^ true ].
+	^ super _compareProperty: propertyKey propertyVaue: propertyValue againstBaseValue: baseValue
+]
+
+{ #category : '*rowan-core-definitions-extensions' }
 RwProjectDefinition >> compareAgainstBase: aDefinition [
 
 	| modification packagesModification |
@@ -15,4 +26,10 @@ RwProjectDefinition >> compareAgainstBase: aDefinition [
 		elementClass: RwPackageDefinition.
 	modification packagesModification: packagesModification.
 	^ modification
+]
+
+{ #category : '*rowan-core-definitions-extensions' }
+RwProjectDefinition >> projectDefinitionSourceProperty [
+
+	^ properties at: RwLoadedProject _projectDefinitionSourceKey ifAbsent: [ 'unknown' ]
 ]

--- a/rowan/src/Rowan-Core/RwLoadedProject.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedProject.class.st
@@ -152,6 +152,14 @@ RwLoadedProject >> packageNames [
 	^ self loadedPackages keys asArray
 ]
 
+{ #category : 'accessing' }
+RwLoadedProject >> projectUrl [
+
+	"Return the projectUrl used to clone the project"
+
+	^ self specification projectUrl
+]
+
 { #category : 'definitions' }
 RwLoadedProject >> propertiesForDefinition [
 

--- a/rowan/src/Rowan-Core/RwLoadedProject.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedProject.class.st
@@ -8,6 +8,32 @@ Class {
 	#category : 'Rowan-Core'
 }
 
+{ #category : 'accessing' }
+RwLoadedProject class >> _projectDefinitionSourceKey [
+	"The value of the property key indicates which source the project definition was derived from.
+		Currently used when deciding whether to change the loaded commit id, during a load ... 
+		if the load is derived from a loaded project (RwLoadedProject class _projectDefinitionSourceValue), 
+		then it isn't necessary to update the loaded commit id."
+
+	^ '_Project_Definition_Source'
+]
+
+{ #category : 'accessing' }
+RwLoadedProject class >> _projectDiskDefinitionSourceValue [
+	"This value of the property key indicates that the source of the project definition was loaded from disk, 
+		then it isn't necessary to update the loaded commit id."
+
+	^ 'loaded from disk'
+]
+
+{ #category : 'accessing' }
+RwLoadedProject class >> _projectLoadedDefinitionSourceValue [
+	"This value of the property key indicates that the source of the project definition was derived from
+		a loaded project, then it isn't necessary to update the loaded commit id."
+
+	^ 'loaded project'
+]
+
 { #category : 'instance creation' }
 RwLoadedProject class >> newForLoadSpecification: aLoadSpecification [
 
@@ -166,6 +192,7 @@ RwLoadedProject >> propertiesForDefinition [
 	| props |
 	props := super propertiesForDefinition.
 	props at: 'name' put: name.
+	props at: self class _projectDefinitionSourceKey put: self class _projectLoadedDefinitionSourceValue.
 	^ props
 ]
 

--- a/rowan/src/Rowan-Core/RwLoadedProject.class.st
+++ b/rowan/src/Rowan-Core/RwLoadedProject.class.st
@@ -34,6 +34,13 @@ RwLoadedProject class >> _projectLoadedDefinitionSourceValue [
 	^ 'loaded project'
 ]
 
+{ #category : 'accessing' }
+RwLoadedProject class >> _projectUnknownDefinitionSourceValue [
+	"This value of the property key indicates that the source of the project definition is unknown."
+
+	^ 'unknown'
+]
+
 { #category : 'instance creation' }
 RwLoadedProject class >> newForLoadSpecification: aLoadSpecification [
 

--- a/rowan/src/Rowan-Core/RwProject.class.st
+++ b/rowan/src/Rowan-Core/RwProject.class.st
@@ -49,6 +49,7 @@ RwProject >> definedClasses [
 { #category : 'testing' }
 RwProject >> existsOnDisk [
 
+	Rowan image loadedProjectNamed: self name ifAbsent: [ ^false ].
 	^ Rowan platform fileUtilities directoryExists: self repositoryRootPath.
 ]
 

--- a/rowan/src/Rowan-Core/RwProject.class.st
+++ b/rowan/src/Rowan-Core/RwProject.class.st
@@ -46,6 +46,12 @@ RwProject >> definedClasses [
 	^ self _projectTools query classForProjectNamed: self name
 ]
 
+{ #category : 'testing' }
+RwProject >> existsOnDisk [
+
+	^ Rowan platform fileUtilities directoryExists: self repositoryRootPath.
+]
+
 { #category : 'accessing' }
 RwProject >> extendedClasses [
 

--- a/rowan/src/Rowan-Core/RwProject.class.st
+++ b/rowan/src/Rowan-Core/RwProject.class.st
@@ -90,6 +90,14 @@ RwProject >> project [
 	^ self
 ]
 
+{ #category : 'accessing' }
+RwProject >> projectUrl [
+
+	"Return the projectUrl used to clone the project"
+
+	^ self _loadedProject projectUrl
+]
+
 { #category : 'project creation' }
 RwProject >> register [
 	"Create a loaded project based on the receiver's properties in the image."

--- a/rowan/src/Rowan-Definitions/RwProjectDefinition.class.st
+++ b/rowan/src/Rowan-Definitions/RwProjectDefinition.class.st
@@ -51,15 +51,6 @@ RwProjectDefinition class >> withProperties: properties packageDefinitions: pack
 		yourself
 ]
 
-{ #category : 'private' }
-RwProjectDefinition >> _compareProperty: propertyKey propertyVaue: propertyValue againstBaseValue: baseValue [
-
-	propertyKey = 'spec' ifFalse: [ ^ super _compareProperty: propertyKey propertyVaue: propertyValue againstBaseValue: baseValue ].
-	"spec entries are considered to be equal for comparison purposes"
-	^ true
-
-]
-
 { #category : 'accessing' }
 RwProjectDefinition >> addOrUpdatePackage: aPackageDefinition [
 

--- a/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/Rowan.extension.st
@@ -1,0 +1,55 @@
+Extension { #name : 'Rowan' }
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> clearGlobalAutomaticClassInitializationBlackList [
+
+	"Clear global list of project names for which automatic class initialiation should be disabled.
+		user black list only applies to current user."
+
+	^ self platform clearAutomaticClassInitializationBlackList_global
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> clearSessionAutomaticClassInitializationBlackList [
+
+	"Clear session list of project names for which automatic class initialiation should be disabled.
+		Session black list only active for duration of GemStone session."
+
+	^ self platform clearAutomaticClassInitializationBlackList_session
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> clearUserAutomaticClassInitializationBlackList [
+
+	"Clear user list of project names for which automatic class initialiation should be disabled.
+		user black list only applies to current user."
+
+	^ self platform clearAutomaticClassInitializationBlackList_user
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> globalAutomaticClassInitializationBlackList [
+
+	"Answer global list of project names for which automatic class initialiation should be disabled.
+		Session black list only active for duration of GemStone session."
+
+	^ self platform automaticClassInitializationBlackList_global
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> sessionAutomaticClassInitializationBlackList [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled.
+		Session black list only active for duration of GemStone session."
+
+	^ self platform automaticClassInitializationBlackList_session
+]
+
+{ #category : '*rowan-gemstone-core' }
+Rowan class >> userAutomaticClassInitializationBlackList [
+
+	"Answer user list of project names for which automatic class initialiation should be disabled.
+		user black list only applies to current user."
+
+	^ self platform automaticClassInitializationBlackList_user
+]

--- a/rowan/src/Rowan-GemStone-Core/RwGsFileUtilities.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsFileUtilities.class.st
@@ -88,8 +88,8 @@ RwGsFileUtilities class >> directoryEntriesFrom: aDirectory [
 { #category : 'utilities' }
 RwGsFileUtilities class >> directoryExists: aDirectory [
 
-	^GsFile existsOnServer: aDirectory
-
+	"handle the case where GsFile class>>existsOnServer: returns nil"
+	^ (GsFile existsOnServer: aDirectory) == true
 ]
 
 { #category : 'utilities' }
@@ -122,7 +122,7 @@ RwGsFileUtilities class >> endsWithSpecial: filename [
 RwGsFileUtilities class >> ensureDirectoryExists: aDirectory [
 
 	| lastSeparator |
-	(GsFile existsOnServer: aDirectory) ifTrue: [^aDirectory].
+	(GsFile existsOnServer: aDirectory) == true ifTrue: [^aDirectory].
 	(GsFile createServerDirectory: aDirectory) ifNotNil: [^aDirectory].
 	lastSeparator := aDirectory findLastSubString: self pathNameDelimiter
 				startingAt: aDirectory size.

--- a/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsImage.class.st
@@ -22,14 +22,13 @@ RwGsImage class >> _loadedProjectRegistryForUserId: aUserId [
 		ifFalse: [
 			"do not have permissions to read objects created by <aUserId>"
 			^ nil ].
-	userPlatformDict := RwPlatform _userPlatformDictionary.
+	userPlatformDict := RwPlatform _userPlatformDictionaryForUser: aUserId.
 	^ userPlatformDict
 		at: #'RwGsLoadedProjectRegistry'
 		ifAbsent: [ 
 			(self currentUserId = aUserId)
 				ifFalse: [ ^ nil ].
 			userPlatformDict at: #'RwGsLoadedProjectRegistry' put: StringKeyValueDictionary new ]
-
 ]
 
 { #category : 'cypress (old)' }

--- a/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsPlatform.class.st
@@ -26,6 +26,12 @@ RwGsPlatform >> _alternateImageClass: anImageClass [
 ]
 
 { #category : 'private' }
+RwGsPlatform >> _globalPreferenceDict [
+
+	^ (self class _userPlatformDictionaryForUser: 'SystemUser') at: #RwGlobalPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
+{ #category : 'private' }
 RwGsPlatform >> _parseMethod: source category: cat using: aSymbolList environmentId: anEnvironmentId [
 	"Compiles the method into disposable dictionaries, if possible.
 	 Attempts auto-recompile for undefinedSymbols.
@@ -73,6 +79,50 @@ RwGsPlatform >> _parseMethod: source category: cat using: aSymbolList environmen
 					with: [:ex | ex resume])
 ]
 
+{ #category : 'private' }
+RwGsPlatform >> _sessionPreferenceDict [
+
+	^ SessionTemps current at: #RwSessionPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
+{ #category : 'private' }
+RwGsPlatform >> _userPreferenceDict [
+
+	^ self class _userPlatformDictionary at: #RwUserPlatform_Preferences ifAbsentPut: [ Dictionary new ]
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> automaticClassInitializationBlackList_session [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		sessionPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setSessionPreferenceFor: preferenceSymbol to: list.
+			list ]
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> automaticClassInitializationBlackList_user [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		userPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setUserPreferenceFor: preferenceSymbol to: list.
+			list ]
+]
+
 { #category : 'queries' }
 RwGsPlatform >> basePlatformAttribute [
 	"Answer the generic configuration attribute for the platform"
@@ -82,12 +132,96 @@ RwGsPlatform >> basePlatformAttribute [
 
 ]
 
+{ #category : 'preferences' }
+RwGsPlatform >> clearAllPreferencesFor: preferenceSymbol [
+
+
+	self 
+		clearSessionPreferenceFor: preferenceSymbol;
+		clearUserPreferenceFor: preferenceSymbol;
+		clearGlobalPreferenceFor: preferenceSymbol;
+		yourself
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> clearAutomaticClassInitializationBlackList_global [
+
+	"Answer global list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearGlobalPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> clearAutomaticClassInitializationBlackList_session [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearSessionPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'automatic class initialization' }
+RwGsPlatform >> clearAutomaticClassInitializationBlackList_user [
+
+	"Answer session list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearUserPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearDefaultPreferenceFor: preferenceSymbol [
+	"global preferences implements default preference"
+
+	self clearGlobalPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> clearGlobalPreferenceFor: preferenceSymbol [
+
+	self _globalPreferenceDict removeKey: preferenceSymbol ifAbsent: []
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> clearPreferenceFor: preferenceSymbol [
+	"clear sessoin and userPreferences - preserve non-gemstone semantics"
+
+	self 
+		clearSessionPreferenceFor: preferenceSymbol;
+		clearUserPreferenceFor: preferenceSymbol;
+		yourself
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> clearSessionPreferenceFor: preferenceSymbol [
+
+	self _sessionPreferenceDict removeKey: preferenceSymbol ifAbsent: []
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> clearUserPreferenceFor: preferenceSymbol [
+
+	self _userPreferenceDict removeKey: preferenceSymbol ifAbsent: []
+]
+
 { #category : 'defaults' }
 RwGsPlatform >> defaultConfiguration [
 
 	^ RwConfiguration new
 		packageInfoSource: #'SymbolDictionary';
 		yourself
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> defaultPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	"global preferences implements default preference"
+
+	^self globalPreferenceFor: preferenceSymbol ifAbsent: aBlock
 ]
 
 { #category : 'queries' }
@@ -105,6 +239,14 @@ RwGsPlatform >> globalNamed: aString [
 	^ Rowan image objectNamed: aString
 ]
 
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> globalPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _globalPreferenceDict 
+		at: preferenceSymbol 
+		ifAbsent: aBlock
+]
+
 { #category : 'queries' }
 RwGsPlatform >> image [
 
@@ -116,6 +258,7 @@ RwGsPlatform >> image [
 { #category : 'initialization' }
 RwGsPlatform >> initialize [
 
+	self automaticClassInitializationBlackList
 ]
 
 { #category : 'queries' }
@@ -158,4 +301,69 @@ RwGsPlatform >> platformConfigurationAttributes [
 
 	^ super platformConfigurationAttributes, {self basePlatformAttribute. 'gemstone-kernel'. (System stoneVersionReport at: 'gsVersion') asRwGemStoneVersionNumber}
 
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _sessionPreferenceDict 
+		at: preferenceSymbol 
+		ifAbsent: [ 
+			self 
+				_userPreferenceDict at: preferenceSymbol 
+				ifAbsent: [
+					self _globalPreferenceDict 
+						at: preferenceSymbol
+						ifAbsent:aBlock ] ]
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> sessionPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _sessionPreferenceDict 
+		at: preferenceSymbol 
+		ifAbsent: aBlock
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setDefaultPreferenceFor: preferenceSymbol to: anObject [
+
+	"global preferences implements default preference"
+
+	^self setGlobalPreferenceFor: preferenceSymbol to: anObject
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> setGlobalPreferenceFor: preferenceSymbol to: anObject [
+
+	self _globalPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences' }
+RwGsPlatform >> setPreferenceFor: preferenceSymbol to: anObject [
+
+	"clear session; set userPreferences - preserve non-gemstone semantics"
+
+	self clearSessionPreferenceFor: preferenceSymbol.
+	^self setUserPreferenceFor: preferenceSymbol to: anObject
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> setSessionPreferenceFor: preferenceSymbol to: anObject [
+
+	self _sessionPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> setUserPreferenceFor: preferenceSymbol to: anObject [
+
+	self _userPreferenceDict at: preferenceSymbol put: anObject
+]
+
+{ #category : 'preferences - gemstone' }
+RwGsPlatform >> userPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self _userPreferenceDict 
+		at: preferenceSymbol 
+		ifAbsent: aBlock
 ]

--- a/rowan/src/Rowan-GemStone-Core/RwPlatform.extension.st
+++ b/rowan/src/Rowan-GemStone-Core/RwPlatform.extension.st
@@ -6,12 +6,20 @@ RwPlatform class >> _userPlatformDictionary [
 	"Platform globals are put into the current user's UserGlobals so that the values can be persisted.
 		if the user does not have write access to UserGlobals, we'll store in session-specific dictionary"
 
+	^self _userPlatformDictionaryForUser: RwGsImage currentUserId
+]
+
+{ #category : '*rowan-gemstone-core' }
+RwPlatform class >> _userPlatformDictionaryForUser: aUserId [
+
+	"Platform globals are put into the current user's UserGlobals so that the values can be persisted.
+		if the user does not have write access to UserGlobals, we'll store in session-specific dictionary"
+
 	| userGlobals |
-	userGlobals := System myUserProfile objectNamed: 'UserGlobals'.
+	userGlobals := (AllUsers userWithId: aUserId) objectNamed: 'UserGlobals'.
 	^ (System canWrite: userGlobals)
 		ifTrue: [ userGlobals ]
 		ifFalse: [ SessionTemps current ]
-
 ]
 
 { #category : '*rowan-gemstone-core' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassPatch.class.st
@@ -167,8 +167,10 @@ RwGsClassPatch >> createClassFor: aPatchSet [
 { #category : 'patching moved classes' }
 RwGsClassPatch >> installPropertiesPatchFor: aPatchSet classMove: aClassMove [
 
-	self installPropertiesPatchFor: aPatchSet registry: (self symbolDictionaryRegistryFor: aClassMove packageAfter name)
-
+	| theRegistry |
+	theRegistry := (self symbolDictionaryFor: aClassMove packageAfter name projectDefinition: aClassMove projectAfter)
+		rowanSymbolDictionaryRegistry.
+	self installPropertiesPatchFor: aPatchSet registry: theRegistry
 ]
 
 { #category : 'versioning' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
@@ -218,10 +218,12 @@ RwGsClassVersioningSymbolDictPatch >> moveNewClassVersionInSystem: aClassMove [
 	"Move the class association for the class.
 	 Update the LoadedClass with properties for the new classversion."
 
-	(self symbolDictionaryRegistryFor: aClassMove packageAfter name)
-		addNewClassVersionToAssociation: newClassVersion 
-		implementationClass: RwGsSymbolDictionaryRegistry_Implementation
+	| theRegistry |
+	theRegistry := (self symbolDictionaryFor: aClassMove packageAfter name projectDefinition: aClassMove projectAfter)
+		rowanSymbolDictionaryRegistry.
 
+	theRegistry addNewClassVersionToAssociation: newClassVersion 
+			implementationClass: RwGsSymbolDictionaryRegistry_Implementation
 ]
 
 { #category : 'versioning' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsClassVersioningSymbolDictPatch.class.st
@@ -275,7 +275,7 @@ RwGsClassVersioningSymbolDictPatch >> updateNewClassVersionPatchesForSubclassesI
 			| loadedClass loadedPackage loadedProject loadedClassDefinition subclassName newVersionClassModification 
 				projectModification packageModification classesModification classesModified |
 			subclassName := subclass name asString.
-			loadedClass := self existingSymbolDictionaryRegistry existingForClass: subclass.
+			loadedClass := Rowan image loadedClassNamed: subclassName.
 			loadedClassDefinition := loadedClass asDefinition.
 			loadedPackage := loadedClass loadedPackage.
 			loadedProject := loadedClass loadedProject.
@@ -327,7 +327,6 @@ RwGsClassVersioningSymbolDictPatch >> updateNewClassVersionPatchesForSubclassesI
 				_updateNewClassVersionPatchesForClass: subclass
 				in: aProjectSetModification
 				patchSet: patchSet ]
-
 ]
 
 { #category : 'new version support' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsMethodAdditionSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsMethodAdditionSymbolDictPatch.class.st
@@ -34,7 +34,9 @@ RwGsMethodAdditionSymbolDictPatch >> installMovedMethod: aClassMove newClassVers
 	"https://github.com/dalehenrich/Rowan/issues/316"
 
 	| oldClassVersion oldBehavior theRegistry |
-	theRegistry := self symbolDictionaryRegistryFor: aClassMove packageAfter name. 
+	theRegistry := (self symbolDictionaryFor: aClassMove packageAfter name projectDefinition: aClassMove projectAfter)
+		rowanSymbolDictionaryRegistry.
+
 	oldClassVersion := newClassVersionPatch oldClassVersion.
 	oldClassVersion ~~ newClassVersionPatch newClassVersion
 		ifTrue: [ 
@@ -54,12 +56,11 @@ RwGsMethodAdditionSymbolDictPatch >> installMovedMethod: aClassMove newClassVers
 										'Internal error -- no existing LoadedMethod found for deleted method.' ]
 							ifNotNil: [ :oldLoadedMethod | theRegistry methodRegistry removeKey: oldCompiledMethod ] ] ].
 
-	(self symbolDictionaryRegistryFor: aClassMove packageAfter name)
+	theRegistry
 		addNewCompiledMethod: compiledMethod
 		for: behavior
 		protocol: self propertiesProtocolName
 		toPackageNamed: aClassMove packageAfter name
 		implementationClass: RwGsSymbolDictionaryRegistry_Implementation.
 	selector := compiledMethod selector
-
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsMethodExtensionSymbolDictPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsMethodExtensionSymbolDictPatch.class.st
@@ -34,7 +34,8 @@ RwGsMethodExtensionSymbolDictPatch >> installMovedMethod: aMethodMove newClassVe
 	"https://github.com/dalehenrich/Rowan/issues/316"
 
 	| oldClassVersion oldBehavior theRegistry |
-	theRegistry := self symbolDictionaryRegistryFor: aMethodMove packageAfter name. 
+	theRegistry := (self symbolDictionaryFor: aMethodMove packageAfter name projectDefinition: aMethodMove projectAfter)
+		rowanSymbolDictionaryRegistry.
 	oldClassVersion := newClassVersionPatch oldClassVersion.
 	oldClassVersion ~~ newClassVersionPatch newClassVersion
 		ifTrue: [ 
@@ -54,12 +55,11 @@ RwGsMethodExtensionSymbolDictPatch >> installMovedMethod: aMethodMove newClassVe
 										'Internal error -- no existing LoadedMethod found for deleted method.' ]
 							ifNotNil: [ :oldLoadedMethod | theRegistry methodRegistry removeKey: oldCompiledMethod ] ] ].
 
-	(self symbolDictionaryRegistryFor: aMethodMove packageAfter name)
+	theRegistry
 		addExtensionCompiledMethod: compiledMethod
 		for: behavior
 		protocol: self propertiesProtocolName
 		toPackageNamed: aMethodMove packageAfter name
 		implementationClass: RwGsSymbolDictionaryRegistry_Implementation.
 	selector := compiledMethod selector
-
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatch.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatch.class.st
@@ -65,14 +65,19 @@ RwGsPatch >> symbolDictionary [
 { #category : 'accessing' }
 RwGsPatch >> symbolDictionaryFor: aPackageName [
 
+	^ self symbolDictionaryFor: aPackageName projectDefinition: self projectDefinition
+]
+
+{ #category : 'accessing' }
+RwGsPatch >> symbolDictionaryFor: aPackageName projectDefinition: aProjectDefinition [
+
 	| symDictName symDict |
-	symDictName := self projectDefinition
+	symDictName := aProjectDefinition
 		symbolDictNameForPackageNamed:aPackageName.
 	symDict := GsCurrentSession currentSession symbolList objectNamed: symDictName asSymbol.
 	symDict
 		ifNotNil: [ symDict rowanSymbolDictionaryRegistry ifNotNil: [ ^ symDict ] ].
 	^ Rowan image newOrExistingSymbolDictionaryNamed: symDictName
-
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -651,7 +651,6 @@ RwGsPatchSet_254 >> addPatchedClassNewVersion: aClassModification inPackage: aPa
 				inPackage: aPackageDefinition)
 				projectDefinition: aProjectDefinition;
 				yourself)
-
 ]
 
 { #category : 'building' }
@@ -1382,5 +1381,4 @@ RwGsPatchSet_254 >> updateSymbolAssociations [
 			ifNil: [ each installNewClassVersionInSystem ]
 			ifNotNil: [:aClassMove | each moveNewClassVersionInSystem: aClassMove ].
 		 ]
-
 ]

--- a/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
+++ b/rowan/src/Rowan-GemStone-Loader/RwGsPatchSet_254.class.st
@@ -1212,7 +1212,8 @@ RwGsPatchSet_254 >> runInitializers [
 
 	"run the class initialization methods as needed"
 
-	| methodPatches orderedMethodPatches |
+	| methodPatches orderedMethodPatches blackList |
+	blackList := Rowan automaticClassInitializationBlackList.
 	methodPatches := (addedMethods copy
 		addAll: extendedMethods;
 		addAll: methodsNeedingRecompile;
@@ -1222,10 +1223,11 @@ RwGsPatchSet_254 >> runInitializers [
 		ifTrue: [ self class methodPatchesInInitializationOrder: methodPatches ]
 		ifFalse: [ methodPatches ].
 	orderedMethodPatches do: [ :methodPatch | 
-			(RwExecuteClassInitializeMethodsAfterLoadNotification new
-				candidateClass: methodPatch behavior thisClass) signal 
-					ifTrue: [ methodPatch runInitializer ] ]
-
+		(blackList includes: methodPatch projectDefinition name)
+			ifFalse: [ 
+				(RwExecuteClassInitializeMethodsAfterLoadNotification new
+					candidateClass: methodPatch behavior thisClass) signal 
+						ifTrue: [ methodPatch runInitializer ] ] ]
 ]
 
 { #category : 'private - applying' }

--- a/rowan/src/Rowan-JadeServer/JadeServer.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer.class.st
@@ -1213,12 +1213,10 @@ JadeServer >> currentUserMayEditMethod: aMethod [
 
 { #category : 'category' }
 JadeServer >> debugString: aString fromContext: anObject environment: anInteger [
-
 	anInteger == 0 ifFalse: [self error: 'Only environment 0 is supported in this version!'].
-	^'nil halt. ' , aString
+	^(RowanDebuggerService new debugStringFrom: aString)
 		evaluateInContext: anObject 
-		symbolList: GsSession currentSession symbolList. 
-
+		symbolList: GsSession currentSession symbolList.
 ]
 
 { #category : 'category' }
@@ -2912,8 +2910,6 @@ JadeServer >> printStringOf: anObject to: anInteger [
 	(string := self printStringOf: anObject) size > anInteger ifTrue: [string := (string copyFrom: 1 to: anInteger) , '...'].
 	string := String withAll: (string collect: [:each | (32 <= each asciiValue and: [each asciiValue <= 255]) ifTrue: [each] ifFalse: [$?]]).
 	^string.
-
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer.class.st
@@ -1037,7 +1037,10 @@ JadeServer >> compile: aString frame: anInteger process: aGsProcess [
 	category := self _behavior: aBehavior categoryOfSelector: selector.
 	result := ((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile
 				ifAbsent: [false])
-					ifTrue: [aBehavior rwCompileMethod: aString category: category]
+					ifTrue: [ 
+						[ aBehavior rwCompileMethod: aString category: category ]
+							on: RwExecuteClassInitializeMethodsAfterLoadNotification
+							do: [:ex | ex resume: false ] ]
 					ifFalse: 
 						[self
 							compileMethod: aString
@@ -1045,7 +1048,6 @@ JadeServer >> compile: aString frame: anInteger process: aGsProcess [
 							user: nil
 							inCategory: category].
 	^result
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer.class.st
@@ -5292,6 +5292,7 @@ JadeServer >> updateFromSton: stonString [
 				ifNil: [service update]
 				ifNotNil: [service servicePerform: service command withArguments: service commandArgs]].
 	resultString := STON toString: RowanCommandResult results.
+	RowanService autoCommit ifTrue:[System commitTransaction]. 
 	^resultString
 ]
 

--- a/rowan/src/Rowan-JadeServer/JadeServer64bit.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer64bit.class.st
@@ -145,15 +145,16 @@ JadeServer64bit >> recompile: aMethod withSource: aString [
 	behavior := aMethod inClass.
 	((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile ifAbsent: [false])
 		ifTrue: 
-			[behavior rwCompileMethod: aString
-				category: (self _behavior: behavior categoryOfSelector: aMethod selector).
+			[ [ behavior rwCompileMethod: aString
+				category: (self _behavior: behavior categoryOfSelector: aMethod selector) ]
+					on: RwExecuteClassInitializeMethodsAfterLoadNotification
+					do: [:ex | ex resume: false ].
 			Rowan serviceClass rowanFixMe.	"need to handle compile errors"
 			^true]
 		ifFalse: 
 			[result := aMethod _recompileWithSource: aString.
 			result isNil ifTrue: [^true].	"Bug 41195 returns nil if success so assume it is the same method"
 			^result]
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
@@ -284,15 +284,13 @@ JadeServer64bit3x >> inspect: anObject [
 				self print: (self oopOf: (anObject _primitiveAt: i + namedSize)) on: stream.
 				stream lf] ].
 
-	(string := anObject printString) size > 5000 ifTrue: [string := (string copyFrom: 1 to: 5000) , '...'].
+	(string := anObject printString) size > 100000 ifTrue: [string := (string copyFrom: 1 to: 100000) , '...'].
 	string class == String ifFalse: [
 		string := String withAll: (string collect: [:each | (32 <= each codePoint and: [each codePoint <= 255]) ifTrue: [each] ifFalse: [$?]]).
 	].
 	^stream 
 		nextPutAll: string; 
 		contents.
-
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
+++ b/rowan/src/Rowan-JadeServer/JadeServer64bit3x.class.st
@@ -140,7 +140,9 @@ JadeServer64bit3x >> compileMethod: methodString behavior: aBehavior symbolList:
 	| method warnings | 
 
 	[[((System myUserProfile resolveSymbol: #UserGlobals) value at: #rowanCompile ifAbsent:[false]) ifTrue:[
-			method := aBehavior rwCompileMethod: methodString category: categorySymbol]
+			[ method := aBehavior rwCompileMethod: methodString category: categorySymbol ]
+					on: RwExecuteClassInitializeMethodsAfterLoadNotification
+					do: [:ex | ex resume: false ] ]
 		ifFalse:[
 			method := aBehavior
 			compileMethod: methodString
@@ -158,8 +160,6 @@ JadeServer64bit3x >> compileMethod: methodString behavior: aBehavior symbolList:
 	] on: Error do: [:ex | 
 		ex return: method -> warnings.
 	].
-
-
 ]
 
 { #category : 'category' }

--- a/rowan/src/Rowan-Kernel/Rowan.class.st
+++ b/rowan/src/Rowan-Kernel/Rowan.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : 'Rowan-Kernel'
 }
 
+{ #category : 'public' }
+Rowan class >> automaticClassInitializationBlackList [
+
+	"Answer list of project names for which automatic class initialiation should be disabled."
+
+	^ self platform automaticClassInitializationBlackList
+]
+
 { #category : 'public client services' }
 Rowan class >> classServiceClass [
 
@@ -21,9 +29,35 @@ Rowan class >> classServiceClass [
 ]
 
 { #category : 'public' }
+Rowan class >> clearAutomaticClassInitializationBlackList [
+
+	"Clear list of project names for which automatic class initialiation should be disabled."
+
+	^ self platform clearAutomaticClassInitializationBlackList
+]
+
+{ #category : 'public' }
+Rowan class >> clearDefaultAutomaticClassInitializationBlackList [
+
+	"Clear default list of project names for which automatic class initialiation should be disabled.
+		Individual users may override the black list."
+
+	^ self platform clearAutomaticClassInitializationBlackList_default
+]
+
+{ #category : 'public' }
 Rowan class >> configuration [
 
 	^configuration
+]
+
+{ #category : 'public' }
+Rowan class >> defaultAutomaticClassInitializationBlackList [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled.
+		Individual users may override the black list."
+
+	^ self platform automaticClassInitializationBlackList_default
 ]
 
 { #category : 'private' }

--- a/rowan/src/Rowan-Kernel/RwPlatform.class.st
+++ b/rowan/src/Rowan-Kernel/RwPlatform.class.st
@@ -8,6 +8,60 @@ Class {
 	#category : 'Rowan-Kernel'
 }
 
+{ #category : 'automatic class initialization' }
+RwPlatform >> _automaticClassInitializationBlackList_symbol [
+
+	^#automaticClassInitializationBlackList
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> automaticClassInitializationBlackList [
+
+	"Answer list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		preferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> automaticClassInitializationBlackList_default [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		defaultPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setDefaultPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> automaticClassInitializationBlackList_global [
+
+	"Answer global list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	^ self 
+		globalPreferenceFor: preferenceSymbol 
+		ifAbsent: [
+			| list |
+			list := OrderedCollection new.
+			self setDefaultPreferenceFor: preferenceSymbol to: list.
+			list]
+]
+
 { #category : 'queries' }
 RwPlatform >> basePlatformAttribute [
 	"Answer the generic configuration attribute for the platform"
@@ -17,6 +71,66 @@ RwPlatform >> basePlatformAttribute [
 
 	self subclassResponsibility: #basePlatformAttribute
 
+]
+
+{ #category : 'preferences' }
+RwPlatform >> clearAllPreferencesFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearAllPreferencesFor:
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> clearAutomaticClassInitializationBlackList [
+
+	"Answer list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> clearAutomaticClassInitializationBlackList_default [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearDefaultPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'automatic class initialization' }
+RwPlatform >> clearAutomaticClassInitializationBlackList_global [
+
+	"Answer default list of project names for which automatic class initialiation should be disabled."
+
+	| preferenceSymbol |
+	preferenceSymbol := self _automaticClassInitializationBlackList_symbol.
+	self clearGlobalPreferenceFor: preferenceSymbol
+]
+
+{ #category : 'preferences' }
+RwPlatform >> clearDefaultPreferenceFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearDefaultPreferenceFor:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> clearPreferenceFor: preferenceSymbol [ 
+
+	self subclassResponisbility: #clearPreferenceFor:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> defaultPreferenceFor: preferenceSymbol [
+
+	^ self defaultPreferenceFor: preferenceSymbol ifAbsent: [ self error: 'No preference found for ', preferenceSymbol asString printString ]
+]
+
+{ #category : 'preferences' }
+RwPlatform >> defaultPreferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self subclassResponisbility: #defaultPreferenceFor:ifAbsent:
 ]
 
 { #category : 'queries' }
@@ -51,6 +165,30 @@ RwPlatform >> platformConfigurationAttributes [
 
 	^ #('common')
 
+]
+
+{ #category : 'preferences' }
+RwPlatform >> preferenceFor: preferenceSymbol [
+
+	^ self preferenceFor: preferenceSymbol ifAbsent: [ self error: 'No preference found for ', preferenceSymbol asString printString ]
+]
+
+{ #category : 'preferences' }
+RwPlatform >> preferenceFor: preferenceSymbol ifAbsent: aBlock [
+
+	^ self subclassResponisbility: #preferenceFor:ifAbsent:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> setDefaultPreferenceFor: preferenceSymbol to: anObject [
+
+	self subclassResponisbility: #setDefaultPreferenceFor:to:
+]
+
+{ #category : 'preferences' }
+RwPlatform >> setPreferenceFor: preferenceSymbol to: anObject [
+
+	self subclassResponisbility: #setPreferenceFor:to:
 ]
 
 { #category : 'queries' }

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -15,7 +15,7 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> allTestsIn: classServices [
 	answer := Array new. 
 	classServices do:[:service | answer addAll: service allTests].
@@ -34,7 +34,7 @@ RowanAnsweringService >> answer: anObject [
 	answer := anObject
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> exec: aString [
 
 	"for command line service someday"
@@ -42,12 +42,25 @@ RowanAnsweringService >> exec: aString [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
+RowanAnsweringService >> flipAutoCommit [
+
+	answer := RowanService flipAutoCommit. 
+	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> flipTranscript [
 	self isTranscriptInstalled ifTrue:[
 		self jadeiteServer uninstallTranscript]
 	ifFalse:[
 		self jadeiteServer installTranscript]
+]
+
+{ #category : 'client commands' }
+RowanAnsweringService >> initializeAutoCommit [
+
+	RowanService setAutoCommit: false
 ]
 
 { #category : 'testing' }
@@ -56,7 +69,7 @@ RowanAnsweringService >> isTranscriptInstalled [
 	^self transcriptObject == self jadeiteServer
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> loadedPackageExists: packageName [
 	
 	| actualName |
@@ -67,7 +80,7 @@ RowanAnsweringService >> loadedPackageExists: packageName [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> runMethodTests: methodServices [
 
 	| behavior |
@@ -80,7 +93,7 @@ RowanAnsweringService >> runMethodTests: methodServices [
 	RowanCommandResult addResult: self
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> selectorsMatchingPattern: pattern [
 
 	answer := ((AllUsers userWithId: #SymbolUser) resolveSymbol: #AllSymbols) value.
@@ -89,12 +102,19 @@ RowanAnsweringService >> selectorsMatchingPattern: pattern [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
+RowanAnsweringService >> setAutoCommit: boolean [
+
+	answer := RowanService setAutoCommit: boolean.
+	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> subclassCreationTemplate: className [
 	 (RowanClassService new name: className) subclassCreationTemplate.  "gives an answer for us"
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> transcriptInstalled [
 
 	answer := self isTranscriptInstalled.
@@ -107,7 +127,7 @@ RowanAnsweringService >> transcriptObject [
 	^(SessionTemps current  at: #'TranscriptStream_SessionStream')
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanAnsweringService >> turnOffTranscriptWrites [
 
 	self isTranscriptInstalled ifTrue:[

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -81,6 +81,15 @@ RowanAnsweringService >> loadedPackageExists: packageName [
 ]
 
 { #category : 'client commands' }
+RowanAnsweringService >> printStringOf: oop toMaxSize: integer [
+
+	answer := (Object _objectForOop: oop) printString. 
+	answer := answer size > integer ifTrue: [(answer copyFrom: 1 to: integer) , '...'] ifFalse:[answer].
+	RowanCommandResult addResult: self.
+	^answer
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> runMethodTests: methodServices [
 
 	| behavior |

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -13,6 +13,13 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
+{ #category : 'commands' }
+RowanAnsweringService >> allTestsIn: classServices [
+	answer := Array new. 
+	classServices do:[:service | answer addAll: service allTests].
+	RowanCommandResult addResult: self.
+]
+
 { #category : 'other' }
 RowanAnsweringService >> answer [
 

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -50,6 +50,16 @@ RowanAnsweringService >> exec: aString [
 ]
 
 { #category : 'client commands' }
+RowanAnsweringService >> exec: aString context: anObject [
+
+	answer := (aString evaluateInContext: anObject symbolList: GsSession currentSession symbolList). 
+	RowanCommandResult addResult: self.
+
+	"return answer for testing" 
+	^answer
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> flipTranscript [
 	self isTranscriptInstalled ifTrue:[
 		self jadeiteServer uninstallTranscript]

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -2,7 +2,9 @@
 A place to put miscellaneous commands that don't fit 
 well in other services. 
 
-Also good asking the server questions.
+Also good asking the server questions as it gives back 
+an answer whereas other services simply return updated
+services.
 "
 Class {
 	#name : 'RowanAnsweringService',
@@ -84,8 +86,6 @@ RowanAnsweringService >> selectorsMatchingPattern: pattern [
 	answer := ((AllUsers userWithId: #SymbolUser) resolveSymbol: #AllSymbols) value.
 	answer := answer select: [:each |each _matchPatternNoCase: pattern].
 	answer := answer asSortedCollection asArray.
-	command := nil. 
-	commandArgs := nil. 
 	RowanCommandResult addResult: self.
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -35,17 +35,17 @@ RowanAnsweringService >> answer: anObject [
 ]
 
 { #category : 'client commands' }
-RowanAnsweringService >> exec: aString [
+RowanAnsweringService >> autoCommit [
 
-	"for command line service someday"
-	answer := aString evaluate printString. 
+	answer := RowanService autoCommit. 
 	RowanCommandResult addResult: self.
 ]
 
 { #category : 'client commands' }
-RowanAnsweringService >> flipAutoCommit [
+RowanAnsweringService >> exec: aString [
 
-	answer := RowanService flipAutoCommit. 
+	"for command line service someday"
+	answer := aString evaluate printString. 
 	RowanCommandResult addResult: self.
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -17,6 +17,15 @@ Class {
 }
 
 { #category : 'client commands' }
+RowanBrowserService >> abortTransaction [
+
+	System abortTransaction.
+	self updateProjects.
+	self packagesWithTests.
+	self updateType: #aborted:browser:.
+]
+
+{ #category : 'client commands' }
 RowanBrowserService >> allClasses [
 
 	allClasses := SortedCollection sortBlock: [:x :y | x name < y name].

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -11,7 +11,8 @@ Class {
 		'allClasses',
 		'hierarchyServices',
 		'testPackages',
-		'testCount'
+		'testCount',
+		'autoCommit'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -42,6 +43,15 @@ RowanBrowserService >> allClasses [
 ]
 
 { #category : 'client commands' }
+RowanBrowserService >> autoCommit: boolean [
+
+	RowanService setAutoCommit: boolean.
+	autoCommit := RowanService autoCommit. 
+	updateType := #autoCommitUpdate:.
+	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
 RowanBrowserService >> defaultClassHierarchy [
 	hierarchyServices := Dictionary new.   
 	organizer hierarchy keysAndValuesDo: [:key :value |
@@ -62,6 +72,14 @@ RowanBrowserService >> findRemovedServices: services [
 				RowanCommandResult addResult: service.
 		]
 	].
+]
+
+{ #category : 'client commands' }
+RowanBrowserService >> flipAutoCommit [
+
+	autoCommit := RowanService flipAutoCommit. 
+	updateType := #autoCommitUpdate:.
+	RowanCommandResult addResult: self.
 ]
 
 { #category : 'window registry' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -149,13 +149,13 @@ RowanBrowserService >> removeMethods: methodServices [
 ]
 
 { #category : 'client commands' }
-RowanBrowserService >> saveRootObject: object windowHandle: integer [
+RowanBrowserService >> saveRootObject: oop windowHandle: integer [
 
 	" a window has been opened on the client. Save the 
 	root object of the window so it won't be recycled"
 	| dictionary |
 	dictionary := SessionTemps current at: #rowanServicesWindowRegistry ifAbsentPut: [Dictionary new].
-	dictionary at: integer put: object.
+	dictionary at: integer put: (Object _objectForOop: oop).
 ]
 
 { #category : 'perform' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -16,7 +16,7 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanBrowserService >> allClasses [
 
 	allClasses := SortedCollection sortBlock: [:x :y | x name < y name].
@@ -32,7 +32,7 @@ RowanBrowserService >> allClasses [
 	RowanCommandResult addResult: self
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanBrowserService >> defaultClassHierarchy [
 	hierarchyServices := Dictionary new.   
 	organizer hierarchy keysAndValuesDo: [:key :value |
@@ -44,9 +44,19 @@ RowanBrowserService >> defaultClassHierarchy [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
-RowanBrowserService >> packagesWithTests [
+{ #category : 'client commands' }
+RowanBrowserService >> findRemovedServices: services [
 
+	services do:[:service | 
+		service wasDeleted ifTrue:[
+				service updateType: #removed:.
+				RowanCommandResult addResult: service.
+		]
+	].
+]
+
+{ #category : 'client commands' }
+RowanBrowserService >> packagesWithTests [
 	testPackages := Set new. 
 	testCount := 0. 
 	TestCase allSubclasses do:[:testSubclass |
@@ -63,14 +73,17 @@ RowanBrowserService >> packagesWithTests [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
-RowanBrowserService >> reloadProjects: projectServices [
-
+{ #category : 'client commands' }
+RowanBrowserService >> reloadProjects: projectServices andUpdateServices: services [
+	| projectNames |
 	projectServices do:[:projectService |
-		projectService reloadProject]
+		projectService reloadProject].
+	projectNames := projectServices collect: [:projectService | projectService name]. 
+	services do:[:service | 
+		(projectNames includes: service rowanProjectName) ifTrue:[service update]].
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanBrowserService >> removeMethods: methodServices [
 
 	| notRemoved |
@@ -89,7 +102,12 @@ RowanBrowserService >> removeMethods: methodServices [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'perform' }
+RowanBrowserService >> servicePerform: symbol withArguments: collection [
+	super perform: symbol withArguments: collection.
+]
+
+{ #category : 'client commands' }
 RowanBrowserService >> unloadProjectsNamed: array [
 	array do:[:projectName |
 		Rowan projectTools delete deleteProjectNamed: projectName]. 
@@ -102,7 +120,7 @@ RowanBrowserService >> update [
 	self updateProjects
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanBrowserService >> updateProjects [
 	| sortedProjects | 
 	sortedProjects := SortedCollection sortBlock: [:a :b | a name < b name]. 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -110,7 +110,10 @@ RowanBrowserService >> servicePerform: symbol withArguments: collection [
 { #category : 'client commands' }
 RowanBrowserService >> unloadProjectsNamed: array [
 	array do:[:projectName |
-		Rowan projectTools delete deleteProjectNamed: projectName]. 
+		| project |
+		project := Rowan image loadedProjectNamed: projectName ifAbsent:[].
+		project ifNotNil: [
+			Rowan projectTools delete deleteProjectNamed: projectName]]. 
 	self updateProjects
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -55,6 +55,14 @@ RowanBrowserService >> findRemovedServices: services [
 	].
 ]
 
+{ #category : 'window registry' }
+RowanBrowserService >> openWindows [
+
+	"for testing"
+
+	^SessionTemps current at: #rowanServicesWindowRegistry ifAbsent:[]
+]
+
 { #category : 'client commands' }
 RowanBrowserService >> packagesWithTests [
 	testPackages := Set new. 
@@ -71,6 +79,14 @@ RowanBrowserService >> packagesWithTests [
 	updateType := #testPackages:. 
 	testPackages := testPackages asArray. 
 	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
+RowanBrowserService >> releaseWindowHandle: integer [
+
+	| registry |
+	registry := SessionTemps current at: #rowanServicesWindowRegistry ifAbsent:[^self].
+	registry removeKey: integer ifAbsent: []
 ]
 
 { #category : 'client commands' }
@@ -93,13 +109,26 @@ RowanBrowserService >> removeMethods: methodServices [
 		| classService |
 		classService := RowanClassService forClassNamed: methodService className. 
 		classService meta: methodService meta. 
-		classService removeSelector: methodService selector ifAbsent:[notRemoved add: methodService selector].
+		classService removeSelector: methodService selector ifAbsent:[notRemoved add: methodService].
 		classService updatePackageProject.
+		(notRemoved includes: methodService) ifFalse:[
+			methodService updateType: #removed:.
+			RowanCommandResult addResult: methodService]. 
 		removedMethods add: methodService].
 	notRemoved isEmpty ifFalse:[
-		self error: 'These selectors were not removed - ', notRemoved printString].
+		self error: 'These selectors were not removed - ', (notRemoved collect:[:ea | ea selector]) printString].
 	updateType := #methodsRemoved:. 
 	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
+RowanBrowserService >> saveRootObject: object windowHandle: integer [
+
+	" a window has been opened on the client. Save the 
+	root object of the window so it won't be recycled"
+	| dictionary |
+	dictionary := SessionTemps current at: #rowanServicesWindowRegistry ifAbsentPut: [Dictionary new].
+	dictionary at: integer put: object.
 ]
 
 { #category : 'perform' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -134,7 +134,7 @@ RowanClassService >> basicRefreshFrom: theClass [
 	commandArgs := nil. 
 	superclassName := theClass superClass ifNotNil:[:theSuper | theSuper name asString]. 
 	comment := theClass comment. 
-	organizer ifNil: [organizer := ClassOrganizer new]. "for Jade"
+	organizer ifNil: [organizer := ClassOrganizer new]. "for Jade and tests"
 	versions := theClass classHistory size.
 	version := theClass classHistory indexOf: theClass.
 	template := self classCreationTemplate.
@@ -707,6 +707,7 @@ RowanClassService >> renameCategoryFrom: old to: new [
 
 	| affectedSelectors behavior |
 
+	self update. 
 	self addCategory: new. 
 	behavior := self classOrMeta.
 	affectedSelectors := behavior selectorsIn: old.

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -398,6 +398,7 @@ RowanClassService >> initialize [
 	meta := false. "assume most of our work is on the instance side"
 	selectedPackageServices := Array new.
 	isNewClass := false.
+	methods := Array new.
 ]
 
 { #category : 'initialization' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -35,7 +35,8 @@ Class {
 		'categories',
 		'isTestCase',
 		'expand',
-		'visibleTests'
+		'visibleTests',
+		'isNewClass'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -377,6 +378,7 @@ RowanClassService >> initialize [
 	selectedMethods := Array new.
 	meta := false. "assume most of our work is on the instance side"
 	selectedPackageServices := Array new.
+	isNewClass := false.
 ]
 
 { #category : 'initialization' }
@@ -430,6 +432,11 @@ RowanClassService >> isExtension: boolean [
 
 	isExtension := boolean
 
+]
+
+{ #category : 'Updating' }
+RowanClassService >> isNewClass: boolean [
+	isNewClass := boolean
 ]
 
 { #category : 'Updating' }
@@ -515,7 +522,7 @@ RowanClassService >> minimalRefreshFrom: theClass [
 	instVarNames := classOrMeta instVarNames. 
 	self initializeVariablesFor: classOrMeta. 
 	self initializeCategoriesFor: classOrMeta.
-	self setIsTestCase
+	self setIsTestCase.
 ]
 
 { #category : 'client commands' }
@@ -675,14 +682,18 @@ RowanClassService >> removeCategories: theCategories [
 ]
 
 { #category : 'client commands' }
-RowanClassService >> removeMethods [
+RowanClassService >> removeMethods: methodsToRemove [
 
 	| notRemoved |
 	notRemoved := Array new. 
-	methods do: [:methodService |
-		self removeSelector: methodService selector ifAbsent:[notRemoved add: methodService selector]].
+	methodsToRemove do: [:methodService |
+		self removeSelector: methodService selector ifAbsent:[notRemoved add: methodService].
+		(notRemoved includes: methodService) ifFalse:[
+			methodService updateType: #removed:.
+			RowanCommandResult addResult: methodService
+		]].
 	notRemoved isEmpty ifFalse:[
-		self error: 'These selectors were not removed - ', notRemoved printString].
+		self error: 'These selectors were not removed - ', (notRemoved collect:[:svc | svc selector]) printString].
 ]
 
 { #category : 'rowan' }
@@ -750,7 +761,7 @@ RowanClassService >> runMethodTests: methodServices [
 { #category : 'client commands' }
 RowanClassService >> saveMethodSource: source category: category [
 
-	| behavior compilationResult gsNMethod updatedCategory methodService |
+	| behavior compilationResult gsNMethod updatedCategory methodService |        
 	meta ifNil:[
 				behavior := (Object _objectForOop: oop). 
 				meta := behavior isMeta]

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -29,7 +29,8 @@ Class {
 		'variables',
 		'categories',
 		'isTestCase',
-		'expand'
+		'expand',
+		'visibleTests'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -79,7 +80,7 @@ RowanClassService >> = classService [
 	^name = classService name
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> addCategory: string [
 
 	| theClass |
@@ -87,9 +88,24 @@ RowanClassService >> addCategory: string [
 	theClass := self classFromName.
 	meta ifTrue:[theClass := theClass class]. 
 	theClass addCategory: string.
-	self refreshFrom: self classFromName. 
-	RowanCommandResult addResult: self.
+]
 
+{ #category : 'Accessing' }
+RowanClassService >> allTests [
+	self isTestCase ifFalse:[^Array new]. 
+	name = 'TestCase' ifTrue:[^Array new].
+	^self allTestsWith: Set new
+]
+
+{ #category : 'private' }
+RowanClassService >> allTestsWith: methodServices [
+
+	"assumes that we are in a test class hierarchy"
+	|  superclassService |	
+	methodServices addAll: (methods select:[:service |service selector asString matchPattern: #('test' $*)]). 
+	superclassName = 'TestCase' ifTrue:[^methodServices]. 
+	superclassService := RowanClassService forClassNamed: superclassName.
+	^superclassService allTestsWith: methodServices
 ]
 
 { #category : 'testing' }
@@ -113,6 +129,7 @@ RowanClassService >> basicRefreshFrom: theClass [
 	| classOrMeta theFilters |
 	command := nil. 
 	commandArgs := nil. 
+	superclassName := theClass superClass ifNotNil:[:theSuper | theSuper name asString]. 
 	comment := theClass comment. 
 	organizer ifNil: [organizer := ClassOrganizer new]. "for Jade"
 	versions := theClass classHistory size.
@@ -126,7 +143,8 @@ RowanClassService >> basicRefreshFrom: theClass [
 	self initializeCategoriesFor: classOrMeta.
 	packageName := definedPackageName := classOrMeta rowanPackageName.
 	projectName := classOrMeta rowanProjectName.
-	self setIsTestCase
+	instVarNames := classOrMeta instVarNames. 
+	self setIsTestCase.
 ]
 
 { #category : 'Accessing' }
@@ -138,13 +156,11 @@ RowanClassService >> behavior [
 	^behavior
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> classComment: string [
 	| theClass |
 	theClass := self classFromName. 
 	theClass rwComment: string.
-	self refreshFrom: theClass. 
-	RowanCommandResult addResult: self.
 ]
 
 { #category : 'rowan' }
@@ -160,7 +176,7 @@ RowanClassService >> classFromName [
 	^Rowan globalNamed: name
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> classHierarchy [
 	| behavior |
 	behavior := self classFromName. 
@@ -171,8 +187,6 @@ RowanClassService >> classHierarchy [
 		classService := key == #nil ifTrue:[#nil] ifFalse: [(self hierarchyClassServiceFor: key name) meta: meta].
 		hierarchyServices at: classService put: (self subclassServices: value). 
 	].
-	self refreshFrom: behavior. 
-	RowanCommandResult addResult: self
 ]
 
 { #category : 'Accessing' }
@@ -271,7 +285,7 @@ RowanClassService >> expand: boolean [
 	expand := boolean
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> fileoutCategories: array [
 	| answeringService ws |
 	answeringService := RowanAnsweringService new.
@@ -283,7 +297,7 @@ RowanClassService >> fileoutCategories: array [
 	RowanCommandResult addResult: answeringService.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> fileoutClass [
 	| answeringService ws |
 	answeringService := RowanAnsweringService new.
@@ -294,7 +308,7 @@ RowanClassService >> fileoutClass [
 	RowanCommandResult addResult: answeringService.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> fileoutMethods: array [
 	| answeringService ws |
 	answeringService := RowanAnsweringService new.
@@ -315,18 +329,6 @@ RowanClassService >> filters [
 { #category : 'Updating' }
 RowanClassService >> filters: newValue [
 	filters := newValue
-
-]
-
-{ #category : 'Accessing' }
-RowanClassService >> filterType [
-	^filterType
-
-]
-
-{ #category : 'Updating' }
-RowanClassService >> filterType: newValue [
-	filterType := newValue
 
 ]
 
@@ -480,10 +482,13 @@ RowanClassService >> minimalRefreshFrom: theClass [
 	classOrMeta := meta == true ifTrue:[theClass class] ifFalse:[theClass].
 	packageName := definedPackageName := classOrMeta rowanPackageName.
 	projectName := classOrMeta rowanProjectName.
+	instVarNames := classOrMeta instVarNames. 
+	self initializeVariablesFor: classOrMeta. 
+	self initializeCategoriesFor: classOrMeta.
 	self setIsTestCase
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> moveMethods: methodServices to: category [
 	| behavior |
 	behavior := self classOrMeta.
@@ -491,8 +496,7 @@ RowanClassService >> moveMethods: methodServices to: category [
 			behavior rwMoveMethod: methodService selector toCategory: category.
 			methodService category: category].
 	self update. 
-	self selectedMethods: methodServices. 
-	RowanCommandResult addResult: self.
+	self selectedMethods: methodServices.
 ]
 
 { #category : 'Accessing' }
@@ -512,7 +516,7 @@ RowanClassService >> objectInBaseNamed: aString [
 	^System myUserProfile symbolList objectNamed: aString asSymbol
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> oneLevelClassHierarchy [
 	"good for expanding an existing hierarchy quickly"
 	| behavior sortedSubclasses |
@@ -525,8 +529,6 @@ RowanClassService >> oneLevelClassHierarchy [
 		classService := (self hierarchyClassServiceFor: subclass name) meta: meta.
 		(hierarchyServices at: #expand) add: classService. 
 	].
-	self refreshFrom: behavior. 
-	RowanCommandResult addResult: self
 ]
 
 { #category : 'Accessing' }
@@ -621,9 +623,10 @@ RowanClassService >> refreshMethodsFor: classOrMeta [
 				service ifNotNil:[
 					service accessedInstVars add: instVar asString]
 	]].
+	self setVisibleTests. "methods must be available"
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> removeCategories: theCategories [
 	| theClass  | 
 	self refreshFrom: self classFromName. 
@@ -632,11 +635,9 @@ RowanClassService >> removeCategories: theCategories [
 	theCategories do: [:category |
 		theClass rwRemoveCategory: category.
 		].
-	self refreshFrom: self classFromName. 
-	RowanCommandResult addResult: self
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> removeMethods [
 
 	| notRemoved |
@@ -645,7 +646,6 @@ RowanClassService >> removeMethods [
 		self removeSelector: methodService selector ifAbsent:[notRemoved add: methodService selector]].
 	notRemoved isEmpty ifFalse:[
 		self error: 'These selectors were not removed - ', notRemoved printString].
-	self updateClass.
 ]
 
 { #category : 'rowan' }
@@ -665,7 +665,7 @@ RowanClassService >> removeSelector: selector ifAbsent: absentBlock [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> renameCategoryFrom: old to: new [
 
 	| affectedSelectors behavior |
@@ -678,7 +678,13 @@ RowanClassService >> renameCategoryFrom: old to: new [
 	self removeCategories: (Array with: old)
 ]
 
-{ #category : 'commands' }
+{ #category : 'rowan' }
+RowanClassService >> rowanProjectName [
+
+	^projectName
+]
+
+{ #category : 'client commands' }
 RowanClassService >> runClassTests: classService [
 
 	| behavior |
@@ -690,7 +696,7 @@ RowanClassService >> runClassTests: classService [
 	RowanCommandResult addResult: (RowanAnsweringService new answer: true).
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> runMethodTests: methodServices [
 
 	| behavior |
@@ -701,7 +707,7 @@ RowanClassService >> runMethodTests: methodServices [
 	RowanCommandResult addResult: (RowanAnsweringService new answer: true).
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> saveMethodSource: source category: category [
 
 	| behavior compilationResult gsNMethod updatedCategory methodService |
@@ -726,8 +732,7 @@ RowanClassService >> saveMethodSource: source category: category [
 	methodService := self methodServiceFrom: gsNMethod in: behavior compiltationResult: compilationResult.
 	RowanCommandResult addResult: methodService.
 	self selectedMethods: (Array with: methodService).
-	self updateDirtyState. 
-	RowanCommandResult addResult: self.
+	self updateDirtyState.
 ]
 
 { #category : 'Updating' }
@@ -756,8 +761,8 @@ RowanClassService >> servicePerform: symbol withArguments: collection [
 	| wasClean |
 	wasClean := self arePackageAndProjectClean.
 	super servicePerform: symbol withArguments: collection.
+	self update.
 	wasClean ifTrue:[
-		self update. 
 		self updatePackageProject]
 ]
 
@@ -785,14 +790,20 @@ RowanClassService >> setIsTestCase [
 	isTestCase := self classFromName isSubclassOf: TestCase
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanClassService >> setIsTestCaseCommand [
 
-	self setIsTestCase. 
-	RowanCommandResult addResult: self.
+	self setIsTestCase.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
+RowanClassService >> setVisibleTests [
+	visibleTests := SortedCollection sortBlock: [:x :y | x selector < y selector]. 
+	visibleTests addAll: self allTests.
+	visibleTests := visibleTests asArray.
+]
+
+{ #category : 'client commands' }
 RowanClassService >> subclassCreationTemplate [
 	| answerService |
 	answerService := RowanAnsweringService new. 
@@ -911,4 +922,9 @@ RowanClassService >> versions [
 RowanClassService >> versions: newValue [
 	versions := newValue
 
+]
+
+{ #category : 'testing' }
+RowanClassService >> wasDeleted [
+	^(Rowan globalNamed: name) isNil
 ]

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -192,6 +192,7 @@ RowanClassService >> classHierarchy [
 		classService := key == #nil ifTrue:[#nil] ifFalse: [(self hierarchyClassServiceFor: key name) meta: meta].
 		hierarchyServices at: classService put: (self subclassServices: value). 
 	].
+	RowanCommandResult addResult: self.
 ]
 
 { #category : 'Accessing' }
@@ -300,7 +301,6 @@ RowanClassService >> fastRefresh [
 	| theClass |
 	theClass := self classFromName. 
 	self refreshFrom: theClass. 
-	RowanCommandResult initializeResults. 
 	methods do:[:service |
 			service source: nil; 
 					stepPoints: Array new.
@@ -375,7 +375,7 @@ RowanClassService >> hash [
 { #category : 'private' }
 RowanClassService >> hierarchyClassServiceFor: className [
 	^className asString = name asString ifTrue:[
-			className = 'Object' 
+			className asString = 'Object' 
 				ifTrue:[
 					RowanClassService basicForClassNamed: className]
 				ifFalse:[
@@ -966,6 +966,7 @@ RowanClassService >> updateClass [
 	| theClass |
 	theClass := self classFromName. 
 	theClass isNil ifTrue:[oop := nil. ^self]. 
+	theClass isBehavior ifFalse:[oop := theClass asOop. ^self].
 	self refreshFrom: theClass.
 	RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1,3 +1,8 @@
+"
+Most class operations done here. 
+
+selectedMethods - client side selection. Used after a method compile.
+"
 Class {
 	#name : 'RowanClassService',
 	#superclass : 'RowanService',
@@ -76,8 +81,10 @@ RowanClassService class >> minimalForClassNamed: className [
 
 { #category : 'comparing' }
 RowanClassService >> = classService [
-	(classService isKindOf: RowanClassService) ifFalse:[^false].
-	^name = classService name
+	(classService class canUnderstand: #isClassService) ifFalse:[^false].
+	^classService isClassService
+			ifTrue: [  name asString = classService name asString and: [meta = classService meta]]
+			ifFalse: [^false]
 ]
 
 { #category : 'client commands' }
@@ -92,20 +99,16 @@ RowanClassService >> addCategory: string [
 
 { #category : 'Accessing' }
 RowanClassService >> allTests [
+	| allSelectors theClass |
 	self isTestCase ifFalse:[^Array new]. 
-	name = 'TestCase' ifTrue:[^Array new].
-	^self allTestsWith: Set new
-]
-
-{ #category : 'private' }
-RowanClassService >> allTestsWith: methodServices [
-
-	"assumes that we are in a test class hierarchy"
-	|  superclassService |	
-	methodServices addAll: (methods select:[:service |service selector asString matchPattern: #('test' $*)]). 
-	superclassName = 'TestCase' ifTrue:[^methodServices]. 
-	superclassService := RowanClassService forClassNamed: superclassName.
-	^superclassService allTestsWith: methodServices
+	theClass := self classFromName thisClass.
+	theClass isAbstract ifTrue:[^Array new].
+	allSelectors := self classFromName thisClass allTestSelectors.
+	^allSelectors collect:[:selector | 
+			RowanMethodService forSelector: selector 
+										class: (theClass whichClassIncludesSelector: selector asString)
+										meta: false
+										organizer: organizer].
 ]
 
 { #category : 'testing' }
@@ -346,12 +349,11 @@ RowanClassService >> forClassNamed: className [
 
 { #category : 'comparing' }
 RowanClassService >> hash [
-	^self name hash
+	^self name hash bitXor: meta hash
 ]
 
 { #category : 'private' }
 RowanClassService >> hierarchyClassServiceFor: className [
-
 	^className asString = name asString ifTrue:[
 			className = 'Object' 
 				ifTrue:[
@@ -373,6 +375,8 @@ RowanClassService >> initialize [
 
 	isExtension := false.
 	selectedMethods := Array new.
+	meta := false. "assume most of our work is on the instance side"
+	selectedPackageServices := Array new.
 ]
 
 { #category : 'initialization' }
@@ -382,6 +386,16 @@ RowanClassService >> initializeCategoriesFor: classOrMeta [
 	theFilters := SortedCollection new.
 	classOrMeta env: 0 categorysDo: [:category :selector | theFilters add: category asString].
 	categories := theFilters asOrderedCollection.
+]
+
+{ #category : 'initialization' }
+RowanClassService >> initializeTestMethodsFor: aClass [
+	| testSelectors |
+	(aClass inheritsFrom: TestCase) ifTrue:[
+		aClass isAbstract ifTrue:[^self]. 
+		testSelectors := aClass thisClass suite tests collect:[:method | method selector]. 
+		methods do:[:methodService | 
+			methodService isTestMethod: (testSelectors includes: methodService selector)]].
 ]
 
 { #category : 'initialization' }
@@ -403,6 +417,12 @@ RowanClassService >> instVarNames [
 RowanClassService >> instVarNames: newValue [
 	instVarNames := newValue
 
+]
+
+{ #category : 'testing' }
+RowanClassService >> isClassService [
+
+	^true
 ]
 
 { #category : 'Updating' }
@@ -463,6 +483,13 @@ RowanClassService >> methodsIn: theClass categories: theCategories [
 	theCategories do:[:category |
 		selectors addAll: (theClass selectorsIn: category)]. 
 	^methods select:[:methodService | selectors includes: methodService selector]
+]
+
+{ #category : 'testing' }
+RowanClassService >> methodsNamed: selector [
+	"For testing. Multiple because class could have both instance and class methods"
+
+	^methods select:[:methodService | methodService selector = selector]
 ]
 
 { #category : 'initialization' }
@@ -598,6 +625,12 @@ RowanClassService >> projectIsDirty [
 	^(RowanProjectService new name: behavior rowanProjectName) rowanDirty
 ]
 
+{ #category : 'other' }
+RowanClassService >> projectName [
+
+	^projectName
+]
+
 { #category : 'Updating' }
 RowanClassService >> projectName: newValue [
 	projectName := newValue
@@ -626,6 +659,7 @@ RowanClassService >> refreshMethodsFor: classOrMeta [
 				service ifNotNil:[
 					service accessedInstVars add: instVar asString]
 	]].
+	self initializeTestMethodsFor: classOrMeta thisClass. 
 	self setVisibleTests. "methods must be available"
 ]
 
@@ -690,12 +724,14 @@ RowanClassService >> rowanProjectName [
 { #category : 'client commands' }
 RowanClassService >> runClassTests: classService [
 
+	"if it errors, the client will handle the error. 
+	If it passes, we return true and the client
+	will display decent results." 
 	| behavior |
 	behavior := classService classFromName. 
 	self refreshFrom: behavior.
-	methods do:[:methodService |
-		('test*' match: methodService selector) ifTrue:[ 
-			behavior debug: methodService selector]]. 
+	self tests do:[:methodService |
+			behavior debug: methodService selector]. 
 	RowanCommandResult addResult: (RowanAnsweringService new answer: true).
 ]
 
@@ -734,8 +770,17 @@ RowanClassService >> saveMethodSource: source category: category [
 	self update.  
 	methodService := self methodServiceFrom: gsNMethod in: behavior compiltationResult: compilationResult.
 	RowanCommandResult addResult: methodService.
+	RowanQueryService new 
+			organizer: ClassOrganizer new;
+			hierarchyImplementorsOf: methodService selector inClass: methodService className. "this will update hierarchy method indicators for client"
 	self selectedMethods: (Array with: methodService).
 	self updateDirtyState.
+]
+
+{ #category : 'other' }
+RowanClassService >> selectedMethods [
+	"client side selection. Used after a method compile" 
+	^selectedMethods
 ]
 
 { #category : 'Updating' }
@@ -822,7 +867,7 @@ RowanClassService >> subclassServices: subclasses [
 
 	sortedSubclasses := SortedCollection sortBlock: [:x :y | x name < y name]. 
 	sortedSubclasses addAll: subclasses. 
-	^(sortedSubclasses collect:[:cls | self hierarchyClassServiceFor: cls name]) asArray.
+	^(sortedSubclasses collect:[:cls | (self hierarchyClassServiceFor: cls name) meta: meta]) asArray.
 ]
 
 { #category : 'Accessing' }
@@ -859,6 +904,12 @@ RowanClassService >> template [
 RowanClassService >> template: newValue [
 	template := newValue
 
+]
+
+{ #category : 'private' }
+RowanClassService >> tests [
+
+	^methods select:[:methodService | methodService selector asString matchPattern: #('test' $*)]
 ]
 
 { #category : 'updates' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -261,13 +261,16 @@ RowanClassService >> compileMethod: methodString behavior: aBehavior symbolList:
 
 	| method warnings |
 	
-	[[method := aBehavior rwCompileMethod: methodString category: categorySymbol] on: CompileError
-		do: [:ex | ^nil -> (ex gsArguments at: 1)]]
-			on: CompileWarning
-			do: 
-				[:ex | 
-				warnings := ex warningString.
-				ex resume].
+	[ [ [ method := aBehavior rwCompileMethod: methodString category: categorySymbol  ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | ex resume: false ] ] 
+			on: CompileError
+			do: [:ex | ^nil -> (ex gsArguments at: 1)]]
+				on: CompileWarning
+				do: 
+					[:ex | 
+					warnings := ex warningString.
+					ex resume].
 	^[(self compiledMethodAt: method key selector inClass: aBehavior) -> warnings] on: Error
 		do: [:ex | ex return: method -> warnings]
 ]

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -36,7 +36,8 @@ Class {
 		'isTestCase',
 		'expand',
 		'visibleTests',
-		'isNewClass'
+		'isNewClass',
+		'updateAfterCommand'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -293,6 +294,24 @@ RowanClassService >> expand: boolean [
 ]
 
 { #category : 'client commands' }
+RowanClassService >> fastRefresh [
+	"pushes less information to ston so it's faster"
+
+	| theClass |
+	theClass := self classFromName. 
+	self refreshFrom: theClass. 
+	RowanCommandResult initializeResults. 
+	methods do:[:service |
+			service source: nil; 
+					stepPoints: Array new.
+	visibleTests do:[:service |
+			service source: nil; 
+					stepPoints: Array new].
+			].
+	RowanCommandResult addResult: self.
+]
+
+{ #category : 'client commands' }
 RowanClassService >> fileoutCategories: array [
 	| answeringService ws |
 	answeringService := RowanAnsweringService new.
@@ -463,6 +482,13 @@ RowanClassService >> meta: anObject [
 
 	meta := anObject
 
+]
+
+{ #category : 'Accessing' }
+RowanClassService >> methods [
+
+	"for testing"
+	^methods
 ]
 
 { #category : 'private' }
@@ -821,7 +847,8 @@ RowanClassService >> servicePerform: symbol withArguments: collection [
 	| wasClean |
 	wasClean := self arePackageAndProjectClean.
 	super servicePerform: symbol withArguments: collection.
-	self update.
+	updateAfterCommand == false ifFalse:[
+		self update].
 	wasClean ifTrue:[
 		self updatePackageProject]
 ]

--- a/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
@@ -15,6 +15,10 @@ RowanCommandResult class >> addResult: service [
 	service command: nil;
 			commandArgs: nil. 
 	self updateClientBoundServices: service.
+]
+
+{ #category : 'accessing' }
+RowanCommandResult class >> basicAddResult: service [
 	self results add: service
 ]
 
@@ -54,11 +58,9 @@ RowanCommandResult class >> updateClientBoundServices: clientBoundService [
 	are not canonical, we need to do some housekeeping
 	to ensure that we don't already have this service 
 	somewhere in other client-bound services"
-	
 	(self results includes: clientBoundService) ifTrue:[
-		self removeResult: clientBoundService. 
-		self addResult: clientBoundService. 
-	].
+		self removeResult: clientBoundService].
+	self basicAddResult: clientBoundService. 
 	self results do:[:service |
 		service updateInternalService: clientBoundService.
 		clientBoundService updateInternalService: service].

--- a/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
@@ -11,10 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
-RowanCommandResult class >> addResult: aResult [
-	aResult command: nil;
+RowanCommandResult class >> addResult: service [
+	service command: nil;
 			commandArgs: nil. 
-	self results add: aResult
+	self updateClientBoundServices: service.
+	self results add: service
 ]
 
 { #category : 'initailize' }
@@ -34,10 +35,33 @@ RowanCommandResult class >> new [
 ]
 
 { #category : 'accessing' }
+RowanCommandResult class >> removeResult: aResult [
+
+	self results remove: aResult
+]
+
+{ #category : 'accessing' }
 RowanCommandResult class >> results [
 
 	"lazy initialize for a topaz session test" 
 	^SessionTemps current at: #rowanCommandResults ifAbsentPut: [Array new]
+]
+
+{ #category : 'private' }
+RowanCommandResult class >> updateClientBoundServices: clientBoundService [
+	"We're about to add a service to the results collection. 
+	That service will be sent to the client. Since services
+	are not canonical, we need to do some housekeeping
+	to ensure that we don't already have this service 
+	somewhere in other client-bound services"
+
+	(self results includes: clientBoundService) ifTrue:[
+		self removeResult: clientBoundService. 
+		self addResult: clientBoundService. 
+	].
+	self results do:[:service |
+		service updateInternalService: clientBoundService.
+		clientBoundService updateInternalService: service].
 ]
 
 { #category : 'accessing' }
@@ -61,4 +85,8 @@ RowanCommandResult >> initialize [
 { #category : 'private' }
 RowanCommandResult >> rowanFixMe [
 
+]
+
+{ #category : 'accessing' }
+RowanCommandResult >> updateInternalService: service [
 ]

--- a/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
@@ -54,7 +54,7 @@ RowanCommandResult class >> updateClientBoundServices: clientBoundService [
 	are not canonical, we need to do some housekeeping
 	to ensure that we don't already have this service 
 	somewhere in other client-bound services"
-
+	
 	(self results includes: clientBoundService) ifTrue:[
 		self removeResult: clientBoundService. 
 		self addResult: clientBoundService. 
@@ -80,6 +80,12 @@ RowanCommandResult >> commandArgs: anObject [
 { #category : 'initialization' }
 RowanCommandResult >> initialize [
 
+]
+
+{ #category : 'testing' }
+RowanCommandResult >> isMethodService [
+
+	^false
 ]
 
 { #category : 'private' }

--- a/rowan/src/Rowan-Services-Core/RowanDebuggerService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanDebuggerService.class.st
@@ -8,6 +8,27 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
+{ #category : 'debug string' }
+RowanDebuggerService >> debugStringFrom: aString [
+	| debugStream newStream char | 
+	debugStream := ReadStream on: aString trimLeadingBlanks.
+	debugStream contents isEmpty ifTrue:[^'nil halt.'].
+	newStream := WriteStream on: String new. 
+	((char := debugStream next) = $|) ifTrue:[
+		newStream nextPut: char. 
+		newStream nextPutAll: (debugStream upTo: $|); 
+			nextPut: $|;
+			nextPut: Character space;
+			nextPutAll: 'nil halt. '
+	]
+	ifFalse: [
+		newStream 
+			nextPutAll: 'nil halt. ';
+			nextPut: char]. 		
+	newStream nextPutAll: debugStream upToEnd. 
+	^newStream contents
+]
+
 { #category : 'other' }
 RowanDebuggerService >> update [
 

--- a/rowan/src/Rowan-Services-Core/RowanFrameService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanFrameService.class.st
@@ -38,7 +38,7 @@ RowanFrameService >> initializeProcess: aGsProcess level: anInteger organizer: a
 { #category : 'other' }
 RowanFrameService >> testMethod [
 
-	^7950332623
+	^10023614059
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanFrameService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanFrameService.class.st
@@ -36,12 +36,6 @@ RowanFrameService >> initializeProcess: aGsProcess level: anInteger organizer: a
 ]
 
 { #category : 'other' }
-RowanFrameService >> testMethod [
-
-	^10023614059
-]
-
-{ #category : 'other' }
 RowanFrameService >> varsFor: anArray [
 
 	| keys list receiver values |

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -151,8 +151,7 @@ RowanMethodService >> className [
 
 { #category : 'Updating' }
 RowanMethodService >> className: newValue [
-	className := newValue
-
+	className := newValue asString
 ]
 
 { #category : 'Accessing' }
@@ -230,7 +229,7 @@ RowanMethodService >> forClass: theClass organizer: theOrganizer [
 	breakPoints := self breakPointsFor: gsNMethod.
 	source := gsNMethod sourceString.
 	category := (classOrMeta categoryOfSelector: selector) asString.
-	className := theClass name. 
+	className := theClass name asString. 
 	packageName := gsNMethod rowanPackageName. 
 	projectName := gsNMethod rowanProjectName.
 	self setSupersAndSubsFor: classOrMeta.

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -177,8 +177,11 @@ RowanMethodService >> classService: newValue [
 
 { #category : 'client commands' }
 RowanMethodService >> clearBreakAt: stepPoint [
-
-	self gsNMethod clearBreakAtStepPoint: stepPoint.
+	| method |
+	method := self isUnboundMethod 
+			ifTrue:[Object _objectForOop: oop] 
+			ifFalse:[self gsNMethod].
+	method clearBreakAtStepPoint: stepPoint.
 	self update. 
 	RowanCommandResult addResult: self.
 ]
@@ -324,6 +327,13 @@ RowanMethodService >> isTestMethod: boolean [
 	isTestMethod := boolean
 ]
 
+{ #category : 'testing' }
+RowanMethodService >> isUnboundMethod [
+
+	(className notNil and: [selector notNil]) ifTrue:[^false].
+	^(Object _objectForOop: oop) isKindOf: GsNMethod
+]
+
 { #category : 'Accessing' }
 RowanMethodService >> meta [
 	^meta
@@ -379,9 +389,9 @@ RowanMethodService >> printOn: aStream [
 
 	super printOn: aStream. 
 	aStream nextPut: $(;
-				nextPutAll: className; 
+				nextPutAll: (className ifNil:[nil printString]); 
 				nextPutAll: '>>'; 
-				nextPutAll: selector;
+				nextPutAll: (selector ifNil:[nil printString]);
 				nextPut: $)
 ]
 
@@ -442,8 +452,11 @@ RowanMethodService >> servicePerform: symbol withArguments: collection [
 
 { #category : 'client commands' }
 RowanMethodService >> setBreakAt: stepPoint [
-
-	self gsNMethod setBreakAtStepPoint: stepPoint.
+	| method |
+	method := self isUnboundMethod 
+			ifTrue:[Object _objectForOop: oop] 
+			ifFalse:[self gsNMethod].
+	method setBreakAtStepPoint: stepPoint.
 	self update. 
 	RowanCommandResult addResult: self.
 ]
@@ -481,6 +494,14 @@ RowanMethodService >> source: aString [
 
 ]
 
+{ #category : 'Accessing' }
+RowanMethodService >> stepPoints [
+
+	"for testing"
+	
+	^stepPoints
+]
+
 { #category : 'initialization' }
 RowanMethodService >> stepPointsFor: aGsNMethod [
 	"Answers an Array of Associations (offset -> selector) indexed by step point"
@@ -501,11 +522,13 @@ RowanMethodService >> stepPointsFor: aGsNMethod [
 
 { #category : 'updates' }
 RowanMethodService >> update [
-
-	self wasDeleted ifTrue:[
-		self updateType: #methodsRemoved:. 
-		^RowanCommandResult addResult: self. ].  "removed method"
-	oop ifNil: [oop := self gsNMethod asOop].
+	
+	self isUnboundMethod ifFalse:[
+		self wasRecycled ifTrue:[oop := self gsNMethod asOop].
+		self wasDeleted ifTrue:[
+			self updateType: #methodsRemoved:. 
+			^RowanCommandResult addResult: self. ].  "removed method"
+		oop ifNil: [oop := self gsNMethod asOop]].
 	self 
 		initialize: (Object _objectForOop: oop) 
 		organizer: ClassOrganizer new.
@@ -516,4 +539,10 @@ RowanMethodService >> update [
 RowanMethodService >> wasDeleted [
 	selector isNil ifTrue:[^false].
 	^self gsNMethod isNil
+]
+
+{ #category : 'testing' }
+RowanMethodService >> wasRecycled [
+	(oop notNil and:[self gsNMethod asOop ~= oop]) ifTrue:[^true].
+	^false
 ]

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -26,7 +26,8 @@ Class {
 		'breakPoints',
 		'testResult',
 		'definedPackage',
-		'isTestMethod'
+		'isTestMethod',
+		'testRunClassName'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -424,6 +425,7 @@ RowanMethodService >> runTest: testSelector inClassName: theClassName [
 	sunitTestResult errorCount > 0 ifTrue:[testResult := 'error']. 
 	sunitTestResult failureCount > 0 ifTrue:[testResult := 'failure']. 
 	sunitTestResult passedCount > 0 ifTrue:[testResult := 'passed']. 
+	testRunClassName := theClassName. 
 	RowanCommandResult addResult: self.
 ]
 
@@ -511,6 +513,12 @@ RowanMethodService >> stepPoints [
 	"for testing"
 	
 	^stepPoints
+]
+
+{ #category : 'Updating' }
+RowanMethodService >> stepPoints: collection [
+
+	stepPoints := collection
 ]
 
 { #category : 'initialization' }

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -88,7 +88,7 @@ RowanMethodService >> addOrUpdateMethod [
                    inPackageNamed: self classService packageName
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanMethodService >> allReferences [
 
 	| methods |
@@ -167,7 +167,7 @@ RowanMethodService >> classService: newValue [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanMethodService >> clearBreakAt: stepPoint [
 
 	self gsNMethod clearBreakAtStepPoint: stepPoint.
@@ -193,7 +193,7 @@ RowanMethodService >> definitionClass [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanMethodService >> fileout [
 	| answeringService ws |
 	answeringService := RowanAnsweringService new.
@@ -228,7 +228,7 @@ RowanMethodService >> forClass: theClass organizer: theOrganizer [
 { #category : 'Accessing' }
 RowanMethodService >> gsNMethod [
 
-	^self classOrMeta compiledMethodAt: selector
+	^[self classOrMeta compiledMethodAt: selector ] on: Error do:[:ex | nil "removed method"]
 ]
 
 { #category : 'Accessing' }
@@ -357,6 +357,12 @@ RowanMethodService >> rowanIsExtension [
 
 ]
 
+{ #category : 'rowan' }
+RowanMethodService >> rowanProjectName [
+
+	^projectName
+]
+
 { #category : 'Accessing' }
 RowanMethodService >> selectedPackageServices [
 
@@ -385,7 +391,13 @@ RowanMethodService >> selector: aSymbol [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'perform' }
+RowanMethodService >> servicePerform: symbol withArguments: collection [
+	super servicePerform: symbol withArguments: collection.
+	self update.
+]
+
+{ #category : 'client commands' }
 RowanMethodService >> setBreakAt: stepPoint [
 
 	self gsNMethod setBreakAtStepPoint: stepPoint.
@@ -443,9 +455,19 @@ RowanMethodService >> stepPointsFor: aGsNMethod [
 
 { #category : 'updates' }
 RowanMethodService >> update [
+
+	self wasDeleted ifTrue:[
+		self updateType: #methodsRemoved:. 
+		^RowanCommandResult addResult: self. ].  "removed method"
 	oop ifNil: [oop := self gsNMethod asOop].
 	self 
 		initialize: (Object _objectForOop: oop) 
 		organizer: ClassOrganizer new.
 	RowanCommandResult addResult: self.
+]
+
+{ #category : 'testing' }
+RowanMethodService >> wasDeleted [
+
+	^self gsNMethod isNil
 ]

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -416,6 +416,17 @@ RowanMethodService >> rowanProjectName [
 	^projectName
 ]
 
+{ #category : 'client commands' }
+RowanMethodService >> runTest: testSelector inClassName: theClassName [
+
+	| sunitTestResult |
+	sunitTestResult := (Rowan image objectNamed: theClassName) run: testSelector asSymbol.
+	sunitTestResult errorCount > 0 ifTrue:[testResult := 'error']. 
+	sunitTestResult failureCount > 0 ifTrue:[testResult := 'failure']. 
+	sunitTestResult passedCount > 0 ifTrue:[testResult := 'passed']. 
+	RowanCommandResult addResult: self.
+]
+
 { #category : 'Accessing' }
 RowanMethodService >> selectedPackageServices [
 
@@ -518,6 +529,12 @@ RowanMethodService >> stepPointsFor: aGsNMethod [
 	].
 	^list
 
+]
+
+{ #category : 'Accessing' }
+RowanMethodService >> testResult [
+
+	^testResult
 ]
 
 { #category : 'updates' }

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -25,7 +25,8 @@ Class {
 		'accessedInstVars',
 		'breakPoints',
 		'testResult',
-		'definedPackage'
+		'definedPackage',
+		'isTestMethod'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -33,10 +34,9 @@ Class {
 { #category : 'instance creation' }
 RowanMethodService class >> forGsNMethod: aGsNMethod organizer: aClassOrganizer [
 
-	^self basicNew
+	^self new
 		initialize: aGsNMethod organizer: aClassOrganizer;
 		yourself
-
 ]
 
 { #category : 'instance creation' }
@@ -65,6 +65,14 @@ RowanMethodService class >> source: source selector: selector category: category
 		packageName: packageName;
 		meta: boolString == true.
 	^service
+]
+
+{ #category : 'comparing' }
+RowanMethodService >> = methodService [
+	(methodService class canUnderstand: #isMethodService) ifFalse:[^false].
+	methodService isMethodService ifFalse:[^false].
+	^selector = methodService selector
+		and: [className asString = methodService className asString and: [meta = methodService meta]]
 ]
 
 { #category : 'Accessing' }
@@ -221,7 +229,7 @@ RowanMethodService >> forClass: theClass organizer: theOrganizer [
 	className := theClass name. 
 	packageName := gsNMethod rowanPackageName. 
 	projectName := gsNMethod rowanProjectName.
-	self setSupersAndSubsFor: theClass.
+	self setSupersAndSubsFor: classOrMeta.
 	isExtension := self rowanIsExtension.
 ]
 
@@ -229,6 +237,11 @@ RowanMethodService >> forClass: theClass organizer: theOrganizer [
 RowanMethodService >> gsNMethod [
 
 	^[self classOrMeta compiledMethodAt: selector ] on: Error do:[:ex | nil "removed method"]
+]
+
+{ #category : 'comparing' }
+RowanMethodService >> hash [
+	^(selector hash bitXor: className hash) bitXor: meta hash
 ]
 
 { #category : 'Accessing' }
@@ -266,6 +279,7 @@ RowanMethodService >> initialize [
 	hasSupers := false. 
 	hasSubs := false.
 	accessedInstVars := Array new.
+	isTestMethod := false.
 ]
 
 { #category : 'initialization' }
@@ -290,6 +304,24 @@ RowanMethodService >> initialize: aGsNMethod organizer: aClassOrganizer [
 	self 
 		forClass: inClass thisClass 
 		organizer: aClassOrganizer.
+]
+
+{ #category : 'testing' }
+RowanMethodService >> isMethodService [
+
+	^true
+]
+
+{ #category : 'Accessing' }
+RowanMethodService >> isTestMethod [
+
+	^isTestMethod
+]
+
+{ #category : 'Accessing' }
+RowanMethodService >> isTestMethod: boolean [
+
+	isTestMethod := boolean
 ]
 
 { #category : 'Accessing' }
@@ -340,6 +372,17 @@ RowanMethodService >> packageName [
 RowanMethodService >> packageName: newValue [
 	packageName := newValue
 
+]
+
+{ #category : 'printing' }
+RowanMethodService >> printOn: aStream [
+
+	super printOn: aStream. 
+	aStream nextPut: $(;
+				nextPutAll: className; 
+				nextPutAll: '>>'; 
+				nextPutAll: selector;
+				nextPut: $)
 ]
 
 { #category : 'rowan' }
@@ -417,8 +460,11 @@ RowanMethodService >> setSupersAndSubsFor: theClass [
 			superSource := theSuper sourceCodeAt: selector.
 			superDisplayString := theSuper name, '>>', selector].
 		theSuper := theSuper superClass].
-	(organizer allSubclassesOf: theClass) do:[:cls |
-		(hasSubs := cls includesSelector: selector) ifTrue:[^self]].
+	(organizer allSubclassesOf: theClass thisClass) do:[:cls |
+		| aClass |
+		aClass := theClass isMeta ifTrue:[cls class] ifFalse:[cls]. 
+		(hasSubs := aClass includesSelector: selector) ifTrue:[
+		^self]].
 ]
 
 { #category : 'Accessing' }
@@ -468,6 +514,6 @@ RowanMethodService >> update [
 
 { #category : 'testing' }
 RowanMethodService >> wasDeleted [
-
+	selector isNil ifTrue:[^false].
 	^self gsNMethod isNil
 ]

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -74,6 +74,7 @@ RowanPackageService >> compileClass: definitionString [
 	theClass := definitionString evaluate.
 	classService := RowanClassService new name: theClass name. 
 	classService update. 
+	classService isNewClass: true.
 	classService packageName = name 
 		ifTrue:[
 			self selectedClass: classService
@@ -82,6 +83,7 @@ RowanPackageService >> compileClass: definitionString [
 			packageService := RowanPackageService forPackageNamed: classService packageName. 
 			packageService update. 
 			packageService selectedClass: classService].
+	RowanCommandResult addResult: classService.
 ]
 
 { #category : 'rowan' }

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -416,6 +416,22 @@ RowanPackageService >> update [
 ]
 
 { #category : 'updates' }
+RowanPackageService >> updateInternalService: updatedService [
+
+	"when sending services back to the client,
+	verify any services held by this object are 
+	updated. Services know what internal services
+	they contain." 
+
+	1 to: classes size do:[:index |
+		| classesService |
+		classesService := classes at: index. 
+		classesService = updatedService ifTrue:[
+			classes at: index put: updatedService
+		]].
+]
+
+{ #category : 'updates' }
 RowanPackageService >> updateProject [
 	| projectService |
 

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -50,7 +50,7 @@ RowanPackageService >> changes [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> classHierarchy [
 	| superclassChains levels services hierarchies theClasses toExpand |
 	self update. 
@@ -67,17 +67,21 @@ RowanPackageService >> classHierarchy [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> compileClass: definitionString [
 
 	| theClass classService packageService |
 	theClass := definitionString evaluate.
-	classService := RowanClassService forClassNamed: theClass name. 
-	RowanCommandResult addResult: classService.
-	packageService := RowanPackageService forPackageNamed: classService packageName. 
-	packageService update. 
-	packageService selectedClass: classService.
-	classService selectedPackageServices: (Array with: packageService).
+	classService := RowanClassService new name: theClass name. 
+	classService update. 
+	classService packageName = name 
+		ifTrue:[
+			self selectedClass: classService
+		]
+		ifFalse:[
+			packageService := RowanPackageService forPackageNamed: classService packageName. 
+			packageService update. 
+			packageService selectedClass: classService].
 ]
 
 { #category : 'rowan' }
@@ -291,7 +295,7 @@ RowanPackageService >> projectName: newValue [
 	projectName := newValue
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> removeClass: classService [
 
 	self removeClassNamed: classService name. 
@@ -300,7 +304,7 @@ RowanPackageService >> removeClass: classService [
 	RowanCommandResult addResult: classService
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> removeClassNamed: className [
 
 	self browserTool removeClassNamed: className.
@@ -314,6 +318,12 @@ RowanPackageService >> rowanDirty [
 
 ]
 
+{ #category : 'rowan' }
+RowanPackageService >> rowanProjectName [
+
+	^projectName
+]
+
 { #category : 'other' }
 RowanPackageService >> selectedClass [
 	
@@ -322,8 +332,8 @@ RowanPackageService >> selectedClass [
 
 { #category : 'Accessing' }
 RowanPackageService >> selectedClass: classService [
-
-	selectedClass := classService
+	selectedClass := classService.
+	classService selectedPackageServices: (Array with: self)
 ]
 
 { #category : 'perform' }
@@ -331,8 +341,8 @@ RowanPackageService >> servicePerform: symbol withArguments: collection [
 	| wasClean |
 	wasClean := self arePackageAndProjectClean.
 	super servicePerform: symbol withArguments: collection.
+	self update. 
 	wasClean ifTrue:[
-		self update. 
 		self updateProject]
 ]
 
@@ -354,7 +364,7 @@ RowanPackageService >> services: services from: levels expand: toExpand [
 				])]
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> setDefaultTemplate [
 
 	defaultTemplate := self genericClassCreationTemplate.
@@ -369,7 +379,7 @@ RowanPackageService >> superclassChainsFor: behaviors [
 			supers].
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanPackageService >> testClasses [
 
 	testClasses := Set new. 
@@ -416,4 +426,11 @@ RowanPackageService >> updateProject [
 RowanPackageService >> updateProjectName [
 
 	projectName := (Rowan image loadedPackageNamed: name) projectName.
+]
+
+{ #category : 'testing' }
+RowanPackageService >> wasDeleted [
+
+	^(Rowan image loadedPackageNamed: name
+			ifAbsent: []) isNil
 ]

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -384,13 +384,15 @@ RowanPackageService >> testClasses [
 
 	testClasses := Set new. 
 	TestCase allSubclasses do:[:testSubclass |
-		testSubclass selectors do:[:selector |
-			| packageName |
-			(selector size >= 4 and:[
-			(selector copyFrom: 1 to: 4) asString = 'test']) ifTrue:[
-				packageName := (testSubclass compiledMethodAt: selector) rowanPackageName. 
-				packageName = name ifTrue:[
-					testClasses add: (RowanClassService basicForClassNamed: testSubclass name)]]]]. 
+		testSubclass isAbstract ifFalse:[
+			testSubclass suite tests do:[:testClassInstance |
+				| implementingClass |
+				implementingClass := testClassInstance class whichClassIncludesSelector: testClassInstance selector. 
+				(implementingClass compiledMethodAt: testClassInstance selector) rowanPackageName = name ifTrue:[
+					| classService |
+					classService := RowanClassService basicForClassNamed: testSubclass name.
+					testClasses detect:[:testClassService | testClassService name = classService name] ifNone:[
+						testClasses add: classService]]]]]. 
 	updateType := #testClasses:. 
 	testClasses := testClasses asArray. 
 	RowanCommandResult addResult: self.

--- a/rowan/src/Rowan-Services-Core/RowanProcessService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProcessService.class.st
@@ -56,7 +56,7 @@ RowanProcessService class >> onWaitingProcess: aGsProcess [
 RowanProcessService >> initialize: aGsProcess status: aString [
 
 	| theOrganizer |
-	theOrganizer := ClassOrganizer new.
+	theOrganizer := ClassOrganizer new. 
 	frames := Array new: aGsProcess stackDepth.
 	1 to: aGsProcess stackDepth do: [:i | 
 		frames at: i put: (RowanFrameService process: aGsProcess level: i organizer: theOrganizer).

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -10,7 +10,9 @@ Class {
 		'packages',
 		'changes',
 		'existsOnDisk',
-		'isLoaded'
+		'isLoaded',
+		'projectUrl',
+		'rowanProjectsHome'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -71,6 +73,8 @@ RowanProjectService >> basicRefresh [
 	isSkew := self isSkew.
 	sha := self rowanSha.
 	branch := self rowanBranch.
+	projectUrl := self rowanProjectUrl. 
+	rowanProjectsHome := System gemEnvironmentVariable: 'ROWAN_PROJECTS_HOME' .
 	RowanCommandResult addResult: self
 ]
 
@@ -194,6 +198,7 @@ RowanProjectService >> isDirty: aBoolean [
 RowanProjectService >> isSkew [
 	| repositorySha |
 	name isNil ifTrue:[^false].
+	self existsOnDisk ifFalse:[^false]. 
 	repositorySha := [self repositorySha] on: Error do:[:ex | repositorySha := 'not on disk'].
 	^self sha ~= repositorySha
 ]
@@ -203,8 +208,8 @@ RowanProjectService >> loadProjectNamed: aName [
 
 	[Rowan projectTools load loadProjectNamed: aName] 
 		on: Warning
-		do: [ :ex | Transcript cr; show: ex description. ex resume ]
-
+		do: [ :ex | Transcript cr; show: ex description. ex resume ].
+	RowanBrowserService new updateProjects.
 ]
 
 { #category : 'rowan' }
@@ -238,7 +243,7 @@ RowanProjectService >> newGitProject: url root: rootPath useSsh: useSsh [
 		cloneSpecUrl: url
 		gitRootPath: rootPath
 		useSsh: useSsh.
-
+	RowanBrowserService new updateProjects.
 ]
 
 { #category : 'rowan' }
@@ -309,6 +314,18 @@ RowanProjectService >> projects [
 				branch: service rowanBranch;
 				isDirty: service rowanDirty]
 
+]
+
+{ #category : 'accessing' }
+RowanProjectService >> projectUrl [
+
+	^projectUrl
+]
+
+{ #category : 'accessing' }
+RowanProjectService >> projectUrl: anObject [
+
+	projectUrl := anObject
 ]
 
 { #category : 'client commands' }
@@ -385,6 +402,12 @@ RowanProjectService >> rowanDirty [
 RowanProjectService >> rowanProjectName [
 
 	^name
+]
+
+{ #category : 'rowan' }
+RowanProjectService >> rowanProjectUrl [
+
+	^(RwProject newNamed: name) projectUrl
 ]
 
 { #category : 'rowan' }

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -45,11 +45,19 @@ RowanProjectService >> _isSkew [
 	^isSkew
 ]
 
+{ #category : 'comparing' }
+RowanProjectService >> = projectService [
+	^projectService isProjectService ifTrue: [name = projectService name] ifFalse: [^false]
+]
+
 { #category : 'client commands' }
 RowanProjectService >> addPackageNamed: packageName [
 
-	self browserTool addPackageNamed: packageName toProjectNamed: name. 
-	self update.
+	Rowan image loadedPackageNamed: packageName ifAbsent: [
+		self browserTool addPackageNamed: packageName toProjectNamed: name. 
+		self update.
+		^self answer: #added.].
+	self answer: #duplicatePackage
 ]
 
 { #category : 'initialization' }
@@ -153,6 +161,11 @@ RowanProjectService >> defaultProjectName: aString [
 RowanProjectService >> existsOnDisk [
 
 	^existsOnDisk
+]
+
+{ #category : 'comparing' }
+RowanProjectService >> hash [
+	^self name hash
 ]
 
 { #category : 'initialization' }

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -402,8 +402,7 @@ RowanProjectService >> setExistsOnDisk [
 	"might be a better test than #repositorySha for
 	determining if a project exists on disk." 
 
-	[self repositorySha] on: Error do:[:ex | ^existsOnDisk := false].
-	existsOnDisk := true.
+	existsOnDisk := existsOnDisk := (RwProject newNamed: name) existsOnDisk.
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -45,7 +45,7 @@ RowanProjectService >> _isSkew [
 	^isSkew
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> addPackageNamed: packageName [
 
 	self browserTool addPackageNamed: packageName toProjectNamed: name. 
@@ -55,6 +55,7 @@ RowanProjectService >> addPackageNamed: packageName [
 { #category : 'initialization' }
 RowanProjectService >> basicRefresh [
 	(isLoaded := self projectIsLoaded) ifFalse:[
+		existsOnDisk := false. 
 		updateType := #removedProject:. 
 		^RowanCommandResult addResult: self]. 
 	isDirty := self isDirty. 
@@ -80,7 +81,7 @@ RowanProjectService >> branch: anObject [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> changes [
 
 	| projectService jadeServer |
@@ -97,7 +98,7 @@ RowanProjectService >> changes [
 	RowanCommandResult addResult: self.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> checkout: branchName [
 
 	| project branches |
@@ -108,7 +109,7 @@ RowanProjectService >> checkout: branchName [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> commitWithMessage: message [
 	
 	Rowan projectTools write writeProjectNamed: name.
@@ -184,7 +185,7 @@ RowanProjectService >> isSkew [
 	^self sha ~= repositorySha
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> loadProjectNamed: aName [
 
 	[Rowan projectTools load loadProjectNamed: aName] 
@@ -216,7 +217,7 @@ RowanProjectService >> name: anObject [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> newGitProject: url root: rootPath useSsh: useSsh [
 	"set useSsh to false to clone using https:"
 
@@ -297,7 +298,7 @@ RowanProjectService >> projects [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> pullFromGit [
 
 	| project |
@@ -309,7 +310,7 @@ RowanProjectService >> pullFromGit [
 
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> pushToGit [
 
 	| project |
@@ -328,7 +329,7 @@ RowanProjectService >> refresh [
 		packages := self packageServices].
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> reloadProject [
 
 	[Rowan projectTools load loadProjectNamed: name] 
@@ -368,6 +369,12 @@ RowanProjectService >> rowanDirty [
 ]
 
 { #category : 'rowan' }
+RowanProjectService >> rowanProjectName [
+
+	^name
+]
+
+{ #category : 'rowan' }
 RowanProjectService >> rowanSha [
 
 	name isNil ifTrue:[^0].
@@ -384,14 +391,11 @@ RowanProjectService >> rowanSkew [
 
 { #category : 'perform' }
 RowanProjectService >> servicePerform: symbol withArguments: collection [
-	| wasClean |
-	wasClean := [self rowanDirty not] on: Error do:[:ex | false "not loaded"].
 	super servicePerform: symbol withArguments: collection.
-	wasClean ifTrue:[
-		self update]
+	self update.
 ]
 
-{ #category : 'commands' }
+{ #category : 'client commands' }
 RowanProjectService >> setDefaultProject [
 
 	self class defaultProjectName: name
@@ -436,7 +440,23 @@ RowanProjectService >> update [
 	self refresh.
 ]
 
-{ #category : 'commands' }
+{ #category : 'update' }
+RowanProjectService >> updateInternalService: updatedService [
+
+	"when sending services back to the client,
+	verify any services held by this object are 
+	updated. Services know what internal services
+	they contain." 
+
+	1 to: packages size do:[:index |
+		| packageService |
+		packageService := packages at: index. 
+		packageService = updatedService ifTrue:[
+			packages at: index put: updatedService
+		]].
+]
+
+{ #category : 'client commands' }
 RowanProjectService >> write [
 	Rowan projectTools write writeProjectNamed: name
 

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -402,7 +402,7 @@ RowanProjectService >> setExistsOnDisk [
 	"might be a better test than #repositorySha for
 	determining if a project exists on disk." 
 
-	existsOnDisk := existsOnDisk := (RwProject newNamed: name) existsOnDisk.
+	existsOnDisk := (RwProject newNamed: name) existsOnDisk.
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanQueryService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanQueryService.class.st
@@ -13,7 +13,7 @@ RowanQueryService >> browseClassReferences: className [
 	| methods |
 	methods := organizer referencesTo: className asSymbol.
 	queryResults := self methodServicesFrom: methods first.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'private' }
@@ -32,7 +32,7 @@ RowanQueryService >> hierarchyImplementorsOf: selector inClass: className [
 	classes addAll: (organizer allSubclassesOf: behavior). 
 	methods := organizer implementorsOf: selector in: classes.
 	queryResults := self methodServicesFrom: methods.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -45,7 +45,7 @@ RowanQueryService >> hierarchySendersOf: selector inClass: className [
 	classes addAll: (organizer allSubclassesOf: behavior). 
 	methods := organizer sendersOf: selector in: classes.
 	queryResults := self methodServicesFrom: methods first.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -54,8 +54,7 @@ RowanQueryService >> implementorsOf: selector [
 	| methods |
 	methods := organizer implementorsOf: selector asSymbol.
 	queryResults := self methodServicesFrom: methods.
-	RowanCommandResult addResult: self.
-
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -64,7 +63,7 @@ RowanQueryService >> literalReferences: symbol [
 	| methods |
 	methods := organizer referencesToLiteral: symbol.
 	queryResults := self methodServicesFrom: methods first.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -73,8 +72,7 @@ RowanQueryService >> methodsContaining: string [
 	| methods |
 	methods := organizer substringSearch: string.
 	queryResults := self methodServicesFrom: methods first.
-	RowanCommandResult addResult: self.
-
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -94,7 +92,7 @@ RowanQueryService >> projectBranches: projectName [
 	| project  |
 	project := (RwProject newNamed: projectName). 
 	queryResults := Rowan gitTools gitbranchIn: project repositoryRootPath with: ''.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'queries' }
@@ -115,13 +113,21 @@ RowanQueryService >> queryResults [
 	^queryResults
 ]
 
+{ #category : 'private' }
+RowanQueryService >> returnQueryToClient [
+
+	queryResults do:[:service |
+		RowanCommandResult addResult: service].
+	RowanCommandResult addResult: self.
+]
+
 { #category : 'queries' }
 RowanQueryService >> sendersOf: selector [
 
 	| methods |
 	methods := organizer sendersOf: selector asSymbol.
 	queryResults := self methodServicesFrom: methods first.
-	RowanCommandResult addResult: self.
+	self returnQueryToClient.
 ]
 
 { #category : 'ston' }
@@ -136,4 +142,19 @@ RowanQueryService >> stonOn: stonWriter [
 					(self instVarAt: (self class allInstVarNames indexOf: each asSymbol))
 						ifNotNil: [:value | dictionary at: each asSymbol put: value]
 						ifNil: [self stonShouldWriteNilInstVars ifTrue: [dictionary at: each asSymbol put: nil]]]]
+]
+
+{ #category : 'update' }
+RowanQueryService >> updateInternalService: updatedService [
+
+	"when sending services back to the client,
+	verify any services held by this object are 
+	updated. Services know what internal services
+	they contain." 
+	1 to: queryResults size do:[:index |
+		| service |
+		service := queryResults at: index. 
+		service = updatedService ifTrue:[ 
+			queryResults at: index put: updatedService
+		]].
 ]

--- a/rowan/src/Rowan-Services-Core/RowanQueryService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanQueryService.class.st
@@ -92,7 +92,7 @@ RowanQueryService >> projectBranches: projectName [
 	| project  |
 	project := (RwProject newNamed: projectName). 
 	queryResults := Rowan gitTools gitbranchIn: project repositoryRootPath with: ''.
-	self returnQueryToClient.
+	RowanCommandResult addResult: self
 ]
 
 { #category : 'queries' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -48,6 +48,15 @@ RowanService class >> sampleService [
 
 ]
 
+{ #category : 'other' }
+RowanService >> answer: anObject [
+
+	| answeringService |
+	answeringService := RowanAnsweringService new. 
+	answeringService answer: anObject. 
+	RowanCommandResult addResult: answeringService.
+]
+
 { #category : 'rowan' }
 RowanService >> browserTool [
 
@@ -147,6 +156,30 @@ RowanService >> excludedInstVars [
 
 { #category : 'initialization' }
 RowanService >> initialize [
+]
+
+{ #category : 'testing' }
+RowanService >> isClassService [
+
+	^false
+]
+
+{ #category : 'testing' }
+RowanService >> isMethodService [
+
+	^false
+]
+
+{ #category : 'testing' }
+RowanService >> isPackageService [
+
+	^false
+]
+
+{ #category : 'testing' }
+RowanService >> isProjectService [
+
+	^false
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -212,6 +212,15 @@ RowanService >> rowanLoadedPackageNames [
 
 ]
 
+{ #category : 'accessing' }
+RowanService >> rowanProjectName [
+
+	"all services should be able to return a project name
+	even if they are not truly packaged" 
+
+	^nil
+]
+
 { #category : 'samples' }
 RowanService >> sampleSymbolDictionaryName [
 
@@ -221,7 +230,7 @@ RowanService >> sampleSymbolDictionaryName [
 
 { #category : 'perform' }
 RowanService >> servicePerform: symbol withArguments: collection [
-	super perform: symbol withArguments: collection.
+	^super perform: symbol withArguments: collection.
 ]
 
 { #category : 'replication' }
@@ -260,6 +269,16 @@ RowanService >> symbolDictionaryNamed: aName [
 		ifFalse:[
 			self createSymbolDictionaryNamed: aName].
 
+]
+
+{ #category : 'initialization' }
+RowanService >> update [
+]
+
+{ #category : 'update' }
+RowanService >> updateInternalService: updatedService [
+
+	"no internally held services to update"
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -27,6 +27,18 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
+{ #category : 'autocommit' }
+RowanService class >> autoCommit [
+
+	^SessionTemps current at: #'Jadeite_AutoCommit' ifAbsentPut: [false]
+]
+
+{ #category : 'autocommit' }
+RowanService class >> flipAutoCommit [
+
+	^self setAutoCommit: self autoCommit not
+]
+
 { #category : 'instance creation' }
 RowanService class >> new [
 
@@ -46,6 +58,12 @@ RowanService class >> sampleService [
 
 	^self new sampleService
 
+]
+
+{ #category : 'autocommit' }
+RowanService class >> setAutoCommit: boolean [
+
+	^SessionTemps current at: #'Jadeite_AutoCommit' put: boolean
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Tests/JadeServerTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/JadeServerTest.class.st
@@ -105,9 +105,10 @@ JadeServerTest >> test_updateFromSton [
 	stonString := STON toString: (Array with: service).
 	resultString := self jadeiteServer updateFromSton: stonString. 
 	[services := STON fromString: resultString.
-	self assert: services size equals: 1.
-	self assert: (services first isKindOf: RowanQueryService).
-	self assert: (services first queryResults first isKindOf: RowanMethodService).
-	self assert: services first queryResults first selector == #test_updateFromSton]
+	self assert: services size equals: 2.
+	self assert: (services first isKindOf: RowanMethodService).
+	self assert: (services last isKindOf: RowanQueryService).
+	self assert: (services last queryResults first isKindOf: RowanMethodService).
+	self assert: services last queryResults first selector == #test_updateFromSton]
 		ensure: [RowanCommandResult initializeResults.]
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
@@ -15,6 +15,34 @@ RowanAnsweringServiceTest >> setUp [
 ]
 
 { #category : 'tests' }
+RowanAnsweringServiceTest >> test_execCompileError [
+	| gotError |
+
+	gotError := [service exec: '1 +' context: nil] on: CompileError do:[:ex |
+		true].
+	self assert: gotError.
+]
+
+{ #category : 'tests' }
+RowanAnsweringServiceTest >> test_execNilContext [
+
+	self assert: (service exec: '123' context: nil) equals: 123.
+	self assert: (service exec: '$a' context: nil) equals: $a.
+	self assert: (service exec: '''abc''' context: nil) equals: 'abc'.
+	self assert: (service exec: '3+4' context: nil) equals: 7.
+	self assert: (service exec: 'true' context: nil) equals: true.
+	self assert: (service exec: 'false' context: nil) equals: false.
+]
+
+{ #category : 'tests' }
+RowanAnsweringServiceTest >> test_execWithContext [
+
+	self assert: (service exec: 'self' context: 123) equals: 123.
+	self assert: (service exec: 'self size' context: Array new) equals: 0.
+	self assert: (service exec: '1 + self' context: 2) equals: 3.
+]
+
+{ #category : 'tests' }
 RowanAnsweringServiceTest >> test_initializeAutoCommit [
 	| autoCommit | 
 	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.

--- a/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
@@ -15,21 +15,6 @@ RowanAnsweringServiceTest >> setUp [
 ]
 
 { #category : 'tests' }
-RowanAnsweringServiceTest >> test_flipAutoCommit [
-	| autoCommit | 
-	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
-	autoCommit := RowanService autoCommit. 
-	[service flipAutoCommit. 
-	self assert: RowanService autoCommit equals: autoCommit not. 
-	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit not.
-	service flipAutoCommit. 
-	self assert: RowanService autoCommit equals: autoCommit. 
-	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit] ensure: [
-		RowanService setAutoCommit: autoCommit.
-		self assert: RowanService autoCommit equals: autoCommit.]
-]
-
-{ #category : 'tests' }
 RowanAnsweringServiceTest >> test_initializeAutoCommit [
 	| autoCommit | 
 	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.

--- a/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
@@ -5,6 +5,37 @@ Class {
 }
 
 { #category : 'tests' }
+RowanAnsweringServiceTest >> test_flipAutoCommit [
+	| answeringService autoCommit | 
+	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
+	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
+	autoCommit := RowanService autoCommit. 
+	[answeringService flipAutoCommit. 
+	self assert: RowanService autoCommit equals: autoCommit not. 
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit not.
+	answeringService flipAutoCommit. 
+	self assert: RowanService autoCommit equals: autoCommit. 
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit] ensure: [
+		RowanService setAutoCommit: autoCommit.
+		self assert: RowanService autoCommit equals: autoCommit.]
+]
+
+{ #category : 'tests' }
+RowanAnsweringServiceTest >> test_initializeAutoCommit [
+	| answeringService autoCommit | 
+	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
+	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
+	autoCommit := RowanService autoCommit. 
+	self assert: RowanService autoCommit equals: autoCommit.
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit.
+	[answeringService initializeAutoCommit. 
+	self deny: RowanService autoCommit. 
+	self deny: (SessionTemps current at: #'Jadeite_AutoCommit')] ensure: [
+		RowanService setAutoCommit: autoCommit.
+		self assert: RowanService autoCommit equals: autoCommit.]
+]
+
+{ #category : 'tests' }
 RowanAnsweringServiceTest >> test_loadedPackageExists [
 	| answeringService |
 	self jadeiteIssueTested: #issue205 withTitle: 'misspelled extension category name causes trouble'.
@@ -42,4 +73,20 @@ RowanAnsweringServiceTest >> test_matchingPattern [
 	self assert: answeringService answer size > 1. 
 	1 to: answeringService answer size - 1 do:[:idx | 
 		self assert: (answeringService answer at: idx) < (answeringService answer at: idx + 1)].
+]
+
+{ #category : 'tests' }
+RowanAnsweringServiceTest >> test_setAutoCommit [
+	| answeringService autoCommit | 
+	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
+	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
+	autoCommit := RowanService autoCommit. 
+	[answeringService setAutoCommit: true. 
+	self assert: RowanService autoCommit. 
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit').
+	answeringService setAutoCommit: false. 
+	self deny: RowanService autoCommit. 
+	self deny: (SessionTemps current at: #'Jadeite_AutoCommit')] ensure: [
+		RowanService setAutoCommit: autoCommit.
+		self assert: RowanService autoCommit equals: autoCommit.]
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanAnsweringServiceTest.class.st
@@ -1,19 +1,28 @@
 Class {
 	#name : 'RowanAnsweringServiceTest',
 	#superclass : 'RowanServicesTest',
+	#instVars : [
+		'service'
+	],
 	#category : 'Rowan-Services-Tests'
 }
 
+{ #category : 'support' }
+RowanAnsweringServiceTest >> setUp [
+
+	super setUp. 
+	service := RowanAnsweringService new organizer: ClassOrganizer new.
+]
+
 { #category : 'tests' }
 RowanAnsweringServiceTest >> test_flipAutoCommit [
-	| answeringService autoCommit | 
+	| autoCommit | 
 	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
-	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
 	autoCommit := RowanService autoCommit. 
-	[answeringService flipAutoCommit. 
+	[service flipAutoCommit. 
 	self assert: RowanService autoCommit equals: autoCommit not. 
 	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit not.
-	answeringService flipAutoCommit. 
+	service flipAutoCommit. 
 	self assert: RowanService autoCommit equals: autoCommit. 
 	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit] ensure: [
 		RowanService setAutoCommit: autoCommit.
@@ -22,13 +31,12 @@ RowanAnsweringServiceTest >> test_flipAutoCommit [
 
 { #category : 'tests' }
 RowanAnsweringServiceTest >> test_initializeAutoCommit [
-	| answeringService autoCommit | 
+	| autoCommit | 
 	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
-	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
 	autoCommit := RowanService autoCommit. 
 	self assert: RowanService autoCommit equals: autoCommit.
 	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit.
-	[answeringService initializeAutoCommit. 
+	[service initializeAutoCommit. 
 	self deny: RowanService autoCommit. 
 	self deny: (SessionTemps current at: #'Jadeite_AutoCommit')] ensure: [
 		RowanService setAutoCommit: autoCommit.
@@ -37,54 +45,62 @@ RowanAnsweringServiceTest >> test_initializeAutoCommit [
 
 { #category : 'tests' }
 RowanAnsweringServiceTest >> test_loadedPackageExists [
-	| answeringService |
 	self jadeiteIssueTested: #issue205 withTitle: 'misspelled extension category name causes trouble'.
-	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.
 	Rowan packageNames do:[:packageName |
-		self assert: (answeringService loadedPackageExists: packageName) answer].
-	self deny: (answeringService loadedPackageExists: 'AAAA') answer.
-	self deny: (answeringService loadedPackageExists: 'AJsfdjsdf') answer.
-	self assert: (answeringService loadedPackageExists: 'Rowan-Kernel') answer. 
-	self assert: (answeringService loadedPackageExists: 'rowan-kernel') answer. "lower case is accepted"
+		self assert: (service loadedPackageExists: packageName) answer].
+	self deny: (service loadedPackageExists: 'AAAA') answer.
+	self deny: (service loadedPackageExists: 'AJsfdjsdf') answer.
+	self assert: (service loadedPackageExists: 'Rowan-Kernel') answer. 
+	self assert: (service loadedPackageExists: 'rowan-kernel') answer. "lower case is accepted"
 ]
 
 { #category : 'tests' }
 RowanAnsweringServiceTest >> test_matchingPattern [
-	| answeringService randomSymbol | 
+	| randomSymbol | 
 	self jadeiteIssueTested: #issue235 withTitle: 'Need Find Class/Method from console'.
-	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
-	answeringService selectorsMatchingPattern: #('size'). 
-	self assert: answeringService answer size equals: 1. 
-	self assert: answeringService answer first = #size.
+	service selectorsMatchingPattern: #('size'). 
+	self assert: service answer size equals: 1. 
+	self assert: service answer first = #size.
 
-	answeringService selectorsMatchingPattern: #('SIZE').  "no case match"
-	self assert: answeringService answer size equals: 1. 
-	self assert: answeringService answer first = #size.
+	service selectorsMatchingPattern: #('SIZE').  "no case match"
+	self assert: service answer size equals: 1. 
+	self assert: service answer first = #size.
 
-	answeringService selectorsMatchingPattern: #('test_matching' $*). 
-	self assert: answeringService answer size equals: 1.
-	self assert: answeringService answer first = #test_matchingPattern.
+	service selectorsMatchingPattern: #('test_matching' $*). 
+	self assert: service answer size equals: 1.
+	self assert: service answer first = #test_matchingPattern.
 
-	answeringService selectorsMatchingPattern: #($* 'test_matching' ). 
-	self assert: answeringService answer size equals: 0.
+	service selectorsMatchingPattern: #($* 'test_matching' ). 
+	self assert: service answer size equals: 0.
 
 	"sorted result"
-	answeringService selectorsMatchingPattern: #('size' $*). 
-	self assert: answeringService answer size > 1. 
-	1 to: answeringService answer size - 1 do:[:idx | 
-		self assert: (answeringService answer at: idx) < (answeringService answer at: idx + 1)].
+	service selectorsMatchingPattern: #('size' $*). 
+	self assert: service answer size > 1. 
+	1 to: service answer size - 1 do:[:idx | 
+		self assert: (service answer at: idx) < (service answer at: idx + 1)].
+]
+
+{ #category : 'tests' }
+RowanAnsweringServiceTest >> test_maxPrint [
+	self jadeiteIssueTested: #issue398 withTitle: 'String Inspectors don''t display lfs'.
+	self assert: (service printStringOf: 123 asOop toMaxSize: 5) equals: '123'.
+	self assert: (service printStringOf: 123 asOop toMaxSize: 2) equals: '12...'.
+	self assert: (service printStringOf: 'abc' asOop toMaxSize: 2) equals: '''a...'.
+	self assert: (service printStringOf: Object new asOop toMaxSize: 25) equals: 'anObject'.
+	self assert: (service printStringOf: 'ab
+cd' asOop toMaxSize: 25) equals: '''ab
+cd'''.  "includes lf (10) - no ? substitution"
 ]
 
 { #category : 'tests' }
 RowanAnsweringServiceTest >> test_setAutoCommit [
-	| answeringService autoCommit | 
+	| autoCommit | 
 	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
-	answeringService := RowanAnsweringService new organizer: ClassOrganizer new.  
 	autoCommit := RowanService autoCommit. 
-	[answeringService setAutoCommit: true. 
+	[service setAutoCommit: true. 
 	self assert: RowanService autoCommit. 
 	self assert: (SessionTemps current at: #'Jadeite_AutoCommit').
-	answeringService setAutoCommit: false. 
+	service setAutoCommit: false. 
 	self deny: RowanService autoCommit. 
 	self deny: (SessionTemps current at: #'Jadeite_AutoCommit')] ensure: [
 		RowanService setAutoCommit: autoCommit.

--- a/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
@@ -27,7 +27,7 @@ RowanBrowserServiceTest >> test_windowsRegistry [
 	self jadeiteIssueTested: #issue385 withTitle: 'Inspector should keep associated root object alive'.
 	browserService := RowanBrowserService new. 
 	object := Object new. 
-	browserService saveRootObject: object windowHandle: 123456. 
+	browserService saveRootObject: object asOop windowHandle: 123456. 
 	self assert: (browserService openWindows at: 123456) equals: object.
 	browserService releaseWindowHandle: 123456. 
 	self assert: (browserService openWindows at: 123456 ifAbsent:['gone']) equals: 'gone'.

--- a/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
@@ -5,6 +5,22 @@ Class {
 }
 
 { #category : 'tests' }
+RowanBrowserServiceTest >> test_flipAutoCommit [
+	| autoCommit service | 
+	self jadeiteIssueTested: #issue396 withTitle: 'Ability to turn on autocommit would be nice'.
+	autoCommit := RowanService autoCommit. 
+	service := RowanBrowserService new. 
+	[service flipAutoCommit. 
+	self assert: RowanService autoCommit equals: autoCommit not. 
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit not.
+	service flipAutoCommit. 
+	self assert: RowanService autoCommit equals: autoCommit. 
+	self assert: (SessionTemps current at: #'Jadeite_AutoCommit') equals: autoCommit] ensure: [
+		RowanService setAutoCommit: autoCommit.
+		self assert: RowanService autoCommit equals: autoCommit.]
+]
+
+{ #category : 'tests' }
 RowanBrowserServiceTest >> test_windowsRegistry [
 
 	| browserService object |

--- a/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanBrowserServiceTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'RowanBrowserServiceTest',
+	#superclass : 'RowanServicesTest',
+	#category : 'Rowan-Services-Tests'
+}
+
+{ #category : 'tests' }
+RowanBrowserServiceTest >> test_windowsRegistry [
+
+	| browserService object |
+	self jadeiteIssueTested: #issue385 withTitle: 'Inspector should keep associated root object alive'.
+	browserService := RowanBrowserService new. 
+	object := Object new. 
+	browserService saveRootObject: object windowHandle: 123456. 
+	self assert: (browserService openWindows at: 123456) equals: object.
+	browserService releaseWindowHandle: 123456. 
+	self assert: (browserService openWindows at: 123456 ifAbsent:['gone']) equals: 'gone'.
+]

--- a/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
@@ -13,11 +13,24 @@ RowanClassServiceTest >> createClassNamed: className [
 ]
 
 { #category : 'support' }
+RowanClassServiceTest >> loadRowanSample1 [
+
+	RowanProjectService new newGitProject: 'file:$ROWAN_PROJECTS_HOME/Rowan/samples/RowanSample1.ston' root: '$ROWAN_PROJECTS_HOME' useSsh: true. 
+	Rowan projectTools load loadProjectNamed: 'RowanSample1'.
+]
+
+{ #category : 'support' }
+RowanClassServiceTest >> servicesClassInstance [
+
+	^self servicesDefaultClassName evaluate perform: #new
+]
+
+{ #category : 'support' }
 RowanClassServiceTest >> setUp [
 
 	super setUp.
-	self createDefaultClass. 
-	self loadDefaultProject.
+	self createServicesTestClass. 
+	self loadServicesTestProject.
 ]
 
 { #category : 'support' }
@@ -76,20 +89,195 @@ RowanClassServiceTest >> test_classWasDeleted [
 	self assert: classService wasDeleted.
 ]
 
-{ #category : 'tests' }
-RowanClassServiceTest >> test_isTestCase [
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_compileClassInitializer [
+	"if you compile a class side method #initialize, the error 
+	RwExecuteClassInitializeMethodsAfterLoadNotification is signaled. 
+	Ensure that #saveMethodSource:category: doesn't handle it as
+	it should be handled in compileMethod:behavior:symbolList:inCategory:"
+	| classService errorHit methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	selector := #initialize. 
+	classService meta: true. 
+	errorHit := false. 
+	[classService saveMethodSource: selector asString , ' ^$a' category: 'test initialize'] on: 
+		RwExecuteClassInitializeMethodsAfterLoadNotification do:[:ex | errorHit := true.  ex resume: false. ].
+	[self deny: errorHit. 
+	methodService := classService methodsNamed: selector.
+	self assert: methodService size equals: 1. 
+	self assert: methodService first selector equals: selector.
+	self assert: methodService first meta equals: true.
+	self assert: (self servicesDefaultClassName evaluate perform: selector) equals: $a]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: ((self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false))]
+]
 
-	| classService |
-	self jadeiteIssueTested: #issue253 withTitle: 'popup method menu in method list is slow for JadeServer methods'. 
-	classService := RowanClassService forClassNamed: self class.
-	self assert: classService isTestCase.
-	classService isTestCase: false. 
-	self deny: classService isTestCase. 
-	classService setIsTestCaseCommand. 
-	self assert: classService isTestCase.
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_compileMethodNoCategory [
+	"defaults to 'other'"
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #fnoodle. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	self deny: (self servicesDefaultClassName evaluate categoryNames includes: 'other'). 
+	classService saveMethodSource: selector asString, ' ^$a' category: nil.
+	[methodService := classService methodsNamed: selector.
+	self assert: methodService size equals: 1. 
+	self assert: methodService first meta equals: false.
+	self assert: methodService first category equals: 'other'. 
+	self assert: (self servicesDefaultClassName evaluate categoryNames includes: #'other'). 
+	self assert: (self servicesClassInstance perform: selector) equals: $a]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: ((self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false))]
+]
 
-	classService := RowanClassService forClassNamed: 'JadeServer'.
-	self deny: classService isTestCase.
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_dirtyState [
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #simpleMethod. 
+	self loadRowanSample1. "ensure we're in a clean state"
+	self deny: (RowanProjectService newNamed:  'RowanSample1') isDirty.
+	self deny: (RowanPackageService forPackageNamed: 'RowanSample1-Core') isDirty.
+	classService := RowanClassService forClassNamed: 'RowanSample1'.
+	classService saveMethodSource: selector asString,  ' ^123' category: 'abc'.
+	
+	methodService := classService methodsNamed: selector.
+	[self assert: (RowanProjectService newNamed: 'RowanSample1') isDirty.
+	self assert: (RowanPackageService new name: 'RowanSample1-Core') isDirty.]
+			ensure: [
+				Rowan projectTools delete deleteProjectNamed: 'RowanSample1'.]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_selectedMethod [
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #simpleMethod. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	self deny: classService meta. 
+	self deny: (self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false).
+	classService saveMethodSource: selector asString,  ' ^123' category: 'abc'.
+	
+	methodService := classService methodsNamed: selector.
+	[self assert: classService selectedMethods size equals: 1.
+	self assert: classService selectedMethods first selector equals: selector]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: ((self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false))]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_setSuperSubIndicators [
+	| classService superclassMethodService subclassMethodService selector subclassService |
+	selector := #indicatorTesting. 
+	self loadRowanSample1.
+	[classService := RowanClassService forClassNamed: 'RowanSample1'.
+	classService saveMethodSource: selector asString,  ' ^#deleteThisMethod' category: 'abc'.
+	superclassMethodService := (classService methodsNamed: selector) first.
+	self deny: superclassMethodService hasSupers.
+	self deny: superclassMethodService hasSubs.
+	subclassService := RowanClassService forClassNamed: 'RowanSubClass'.
+	subclassService saveMethodSource: selector asString,  ' ^#subclassMethod' category: 'abc'.
+	subclassMethodService := RowanCommandResult results 
+			detect:[:service | service isMethodService
+				and:[service selector = selector and:[service className = #RowanSubClass]]]. "an updated subclass method should be heading back to the client" 
+	superclassMethodService := RowanCommandResult results 
+			detect:[:service | service isMethodService
+				and:[service selector = selector and:[service className = #RowanSample1]]]. "an updated superclass method should be heading back to the client" 
+	self assert: superclassMethodService hasSubs.  
+	self deny: superclassMethodService hasSupers.
+	self assert: subclassMethodService hasSupers.
+	self deny: subclassMethodService hasSubs.
+	]
+			ensure: [
+				Rowan projectTools delete deleteProjectNamed: 'RowanSample1'.]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_simpleCompile [
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #simpleMethod. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	self deny: classService meta. 
+	self deny: (self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false).
+	classService saveMethodSource: selector asString,  ' ^123' category: 'abc'.
+	
+	methodService := classService methodsNamed: selector.
+	[self assert: methodService size equals: 1. 
+	self assert: methodService first selector equals: selector.
+	self assert: methodService first meta equals: false.
+	self assert: methodService first category equals: 'abc'.
+	self assert: (self servicesClassInstance perform: selector) equals: 123.
+	self assert: ((self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: nil) isKindOf: GsNMethod)]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: ((self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false))]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_simpleCompileClassSide [
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	selector := #simpleMethod.
+	classService meta: true. 
+	self assert: classService meta. 
+	self deny: (((self servicesDefaultClassName evaluate perform: #class)  compiledMethodAt: selector otherwise: false)).
+	classService saveMethodSource: selector asString,  ' ^123' category: 'abc'.
+	[methodService := classService methodsNamed: selector.
+	self assert: methodService size equals: 1. 
+	self assert: methodService first selector equals: selector.
+	self assert: methodService first meta equals: true.
+	self assert: methodService first category equals: 'abc'.
+	self assert: (self servicesDefaultClassName evaluate perform: selector) equals: 123.
+	((self servicesDefaultClassName evaluate perform: #class)compiledMethodAt: selector) isKindOf: GsNMethod]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: (((self servicesDefaultClassName evaluate perform: #class)  compiledMethodAt: selector otherwise: false)).]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_simpleCompileOnClassWithoutMetaSet [
+	| classService  methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #noMeta. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService meta: nil.  "possible for meta not to be set but it should have an oop from which to determine" 
+	classService oop: (self servicesDefaultClassName, ' class') evaluate asOop. 
+	self deny: (((self servicesDefaultClassName evaluate perform: #class)  compiledMethodAt: selector otherwise: false)).
+	classService saveMethodSource: selector asString,  ' ^true' category: 'testing'.
+	[methodService := classService methodsNamed: selector.
+	self assert: methodService size equals: 1. 
+	self assert: methodService first selector equals: selector.
+	self assert: methodService first meta equals: true. "we created a class method"
+	self assert: methodService first category equals: 'testing'.
+	self assert: (self servicesDefaultClassName evaluate perform: selector)]
+		ensure: [
+			classService removeSelector: selector ifAbsent: [].
+			self deny: (((self servicesDefaultClassName evaluate perform: #class)  compiledMethodAt: selector otherwise: false)).]
+]
+
+{ #category : 'test method compilation' }
+RowanClassServiceTest >> test_simpleCompileWithoutMetaSet [
+	| classService methodService selector |
+	self jadeiteIssueTested: #issue356 withTitle: 'Add method compilation tests in server services tests'.
+	selector := #noMeta. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService meta: nil.  "possible for meta not to be set but it should have an oop from which to determine" 
+	classService oop: self servicesDefaultClassName evaluate asOop. 
+	self deny: (self servicesDefaultClassName evaluate compiledMethodAt: selector otherwise: false).
+	classService saveMethodSource: selector asString,  ' ^true' category: 'testing'.
+	methodService := classService methodsNamed: selector.
+	self assert: methodService size equals: 1. 
+	self assert: methodService first selector equals: selector.
+	self assert: methodService first meta equals: false. "we created an instance method"
+	self assert: methodService first category equals: 'testing'.
+	self assert: (self servicesClassInstance perform: selector).
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
@@ -13,13 +13,6 @@ RowanClassServiceTest >> createClassNamed: className [
 ]
 
 { #category : 'support' }
-RowanClassServiceTest >> loadRowanSample1 [
-
-	RowanProjectService new newGitProject: 'file:$ROWAN_PROJECTS_HOME/Rowan/samples/RowanSample1.ston' root: '$ROWAN_PROJECTS_HOME' useSsh: true. 
-	Rowan projectTools load loadProjectNamed: 'RowanSample1'.
-]
-
-{ #category : 'support' }
 RowanClassServiceTest >> servicesClassInstance [
 
 	^self servicesDefaultClassName evaluate perform: #new
@@ -31,26 +24,25 @@ RowanClassServiceTest >> setUp [
 	super setUp.
 	self createServicesTestClass. 
 	self loadServicesTestProject.
+	Rowan platform _alternateImageClass: Rowan image testImageClass
 ]
 
 { #category : 'support' }
 RowanClassServiceTest >> tearDown [
 
 	super tearDown.
-	self unloadServicesTestProject
+	Rowan platform _alternateImageClass: nil.
+	self unloadServicesTestProject.
 ]
 
 { #category : 'tests' }
 RowanClassServiceTest >> test_addedProjectNotOnDisk [
 
-	| proj pkg cls projectService |
-	proj := RwProjectDefinition newForGitBasedProjectNamed: 'Azer'.
-	proj repositoryRootPath: '$ROWAN_PROJECTS_HOME/Azer'.
-	Rowan projectTools create createProjectFor: proj.
-	pkg := RwPackageDefinition newNamed: 'Baijan'.
-	proj addPackage: pkg.
+	| projectDefinition packageDefinition classDefinition projectService |
+	projectDefinition := self createNonDiskTestProjectNamed: 'Azer' packageName: 'Baijan'. 
+	[packageDefinition := projectDefinition packageNamed: 'Baijan'.
 
-	cls := RwClassDefinition
+	classDefinition := RwClassDefinition
 		newForClassNamed: #Baijan
 		super: 'Object'
 		instvars: #(name address orderHistory)
@@ -60,13 +52,13 @@ RowanClassServiceTest >> test_addedProjectNotOnDisk [
 		comment: 'a CustomerRecord holds the sales record for a customer.'
 		pools: #()
 		type: 'normal'.
-	pkg addClassDefinition: cls.
-	Rowan projectTools load loadProjectDefinition: proj.
+	packageDefinition addClassDefinition: classDefinition.
+	Rowan projectTools load loadProjectDefinition: projectDefinition.
 
 	(RowanClassService forClassNamed: 'Baijan') update. "<-- walkback occurrred here"
 	projectService := RowanProjectService newNamed: 'Azer'. 
-	[self deny: projectService existsOnDisk.
-	self assert: projectService isSkew]
+	self deny: projectService existsOnDisk.
+	self deny: projectService isSkew]
 		ensure: [RowanBrowserService new unloadProjectsNamed: (Array with: 'Azer')]
 ]
 
@@ -172,10 +164,19 @@ RowanClassServiceTest >> test_selectedMethod [
 
 { #category : 'test method compilation' }
 RowanClassServiceTest >> test_setSuperSubIndicators [
-	| classService superclassMethodService subclassMethodService selector subclassService |
+	| classService superclassMethodService subclassMethodService selector subclassService packageService |
 	selector := #indicatorTesting. 
 	self loadRowanSample1.
-	[classService := RowanClassService forClassNamed: 'RowanSample1'.
+	[packageService := RowanPackageService forPackageNamed: 'RowanSample1-Core'.
+	packageService compileClass: 
+		'RowanSample1 rwSubclass: ''RowanSubClass''
+			instVarNames: #()
+			classVars: #()
+			classInstVars: #()
+			poolDictionaries: #()
+			category: ''RowanSample1-Core''
+			options: #()'.
+	classService := RowanClassService forClassNamed: 'RowanSample1'.
 	classService saveMethodSource: selector asString,  ' ^#deleteThisMethod' category: 'abc'.
 	superclassMethodService := (classService methodsNamed: selector) first.
 	self deny: superclassMethodService hasSupers.

--- a/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
@@ -1,3 +1,6 @@
+"
+Created to test inherited tests on client
+"
 Class {
 	#name : 'RowanClassServiceTest',
 	#superclass : 'RowanServicesTest',
@@ -21,7 +24,7 @@ RowanClassServiceTest >> setUp [
 RowanClassServiceTest >> tearDown [
 
 	super tearDown.
-	self unloadDefaultProject
+	self unloadServicesTestProject
 ]
 
 { #category : 'tests' }
@@ -55,6 +58,25 @@ RowanClassServiceTest >> test_addedProjectNotOnDisk [
 ]
 
 { #category : 'tests' }
+RowanClassServiceTest >> test_classWasDeleted [
+
+	| classService |
+	System commitTransaction. 
+	self jadeiteIssueTested: #issue284 withTitle: '(3.0.49 and 3.0.50) project browser not updated properly on reload of project'.
+	'Object rwSubclass: ''TestClass''
+	instVarNames: #()
+	classVars: #()
+	classInstVars: #()
+	poolDictionaries: #()
+	category: ''Rowan-Services-Tests''
+	options: #()' evaluate.
+	classService := RowanClassService forClassNamed: 'TestClass'. 
+	self deny: classService wasDeleted.
+	System abortTransaction. 
+	self assert: classService wasDeleted.
+]
+
+{ #category : 'tests' }
 RowanClassServiceTest >> test_isTestCase [
 
 	| classService |
@@ -74,9 +96,9 @@ RowanClassServiceTest >> test_isTestCase [
 RowanClassServiceTest >> testAddCategory [
 	| classService behavior |
 	
-	behavior := Rowan globalNamed: self defaultClassName. 
+	behavior := Rowan globalNamed: self servicesDefaultClassName. 
 	self deny: (behavior categoryNames includes: 'fnoodle'). 
-	classService := RowanClassService forClassNamed: self defaultClassName meta: false. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
 	classService addCategory: 'fnoodle'.
 	self assert: (behavior categoryNames includes: #fnoodle).
 ]
@@ -94,9 +116,9 @@ RowanClassServiceTest >> testBehavior [
 { #category : 'tests' }
 RowanClassServiceTest >> testClassComment [
 	| classService className behavior packageService |
-	behavior := Rowan globalNamed: self defaultClassName. 
+	behavior := Rowan globalNamed: self servicesDefaultClassName. 
 	self assert: behavior comment equals: String new. 
-	classService := RowanClassService forClassNamed: self defaultClassName meta: false. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
 	classService classComment: 'This is a test'. 
 	self assert: behavior comment equals: 'This is a test'
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanClassServiceTest.class.st
@@ -36,6 +36,17 @@ RowanClassServiceTest >> tearDown [
 ]
 
 { #category : 'tests' }
+RowanClassServiceTest >> test_addCategory [
+	| classService behavior |
+	
+	behavior := Rowan globalNamed: self servicesDefaultClassName. 
+	self deny: (behavior categoryNames includes: 'fnoodle'). 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
+	classService addCategory: 'fnoodle'.
+	self assert: (behavior categoryNames includes: #fnoodle).
+]
+
+{ #category : 'tests' }
 RowanClassServiceTest >> test_addedProjectNotOnDisk [
 
 	| projectDefinition packageDefinition classDefinition projectService |
@@ -60,6 +71,75 @@ RowanClassServiceTest >> test_addedProjectNotOnDisk [
 	self deny: projectService existsOnDisk.
 	self deny: projectService isSkew]
 		ensure: [RowanBrowserService new unloadProjectsNamed: (Array with: 'Azer')]
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_behavior [
+	"return class or meta class" 
+	| classService |
+	classService := RowanClassService forClassNamed: 'Array' meta: false.
+	self assert: classService behavior equals: Array.
+	classService := RowanClassService forClassNamed: 'OrderedCollection' meta: true.
+	self assert: classService behavior equals: OrderedCollection class
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_classComment [
+	| classService className behavior packageService |
+	behavior := Rowan globalNamed: self servicesDefaultClassName. 
+	self assert: behavior comment equals: String new. 
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
+	classService classComment: 'This is a test'. 
+	self assert: behavior comment equals: 'This is a test'
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_classFromName [
+	"always return thisClass" 
+	| classService |
+	classService := RowanClassService forClassNamed: 'Array' meta: false.
+	self assert: classService classFromName equals: Array.
+	classService := RowanClassService forClassNamed: 'OrderedCollection' meta: true.
+	self assert: classService classFromName equals: OrderedCollection
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_classHierarchy [
+	"return class hierarchy in format client can use.
+	#nil -> #(Object class service)
+	Object class service -> #(RowanService class service) 
+	etc"
+  
+	| classService hierarchy objectClassService rowanServiceService |
+	classService := RowanClassService forClassNamed: 'RowanClassService'.
+	hierarchy := classService classHierarchy hierarchyServices. 
+	self assert: (hierarchy isKindOf: Dictionary). 
+	self assert: ((hierarchy at: #nil) isKindOf: Array).
+	self assert: (hierarchy at: #nil) size equals: 1. 
+	objectClassService := (hierarchy at: #nil) first.
+	self assert: (objectClassService isKindOf: RowanClassService).
+	self assert: objectClassService name equals: 'Object'.
+	rowanServiceService := (hierarchy at: objectClassService) first. 
+	self assert: rowanServiceService name equals: 'RowanService'.
+	self assert: (hierarchy at: rowanServiceService) first name equals: 'RowanClassService'.
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_classHierarchyClassSide [
+	"same as instance side"
+  
+	| classService hierarchy objectClassService rowanServiceService |
+	classService := RowanClassService forClassNamed: 'RowanClassService' meta: true.
+	hierarchy := classService classHierarchy hierarchyServices. 
+	self assert: (hierarchy isKindOf: Dictionary). 
+	self assert: ((hierarchy at: #nil) isKindOf: Array).
+	self assert: (hierarchy at: #nil) size equals: 1. 
+	objectClassService := (hierarchy at: #nil) first.
+	self assert: (objectClassService isKindOf: RowanClassService).
+	self assert: objectClassService name equals: 'Object'.
+	rowanServiceService := (hierarchy at: objectClassService) first. 
+	self assert: rowanServiceService name equals: 'RowanService'.
+	self assert: (hierarchy at: rowanServiceService) first name equals: 'RowanClassService'.
 ]
 
 { #category : 'tests' }
@@ -144,6 +224,52 @@ RowanClassServiceTest >> test_dirtyState [
 				Rowan projectTools delete deleteProjectNamed: 'RowanSample1'.]
 ]
 
+{ #category : 'tests' }
+RowanClassServiceTest >> test_equality [
+
+	| classService1 classService2 |
+	classService1 := RowanClassService forClassNamed: 'RowanClassService'. 
+	classService2 := RowanClassService forClassNamed: 'RowanClassService'. 
+	self assert: classService1 equals: classService2.
+	self deny: classService1 == classService2.
+	self deny: classService1 equals: RowanClassService. 
+	self deny: classService1 equals: #foo.
+	self deny: classService1 equals: (RowanPackageService forPackageNamed: 'Rowan-Services-Tests').
+	self deny: classService1 equals: (RowanProjectService newNamed: 'Rowan').
+	self deny: classService1 equals: (RowanMethodService forSelector: #test_equality class: RowanClassServiceTest meta: false organizer: ClassOrganizer new)
+]
+
+{ #category : 'tests' }
+RowanClassServiceTest >> test_nameIsString [
+
+	| classService |
+	self jadeiteIssueTested: #issue441 withTitle: '(3.0.62) suspicious code in RowanClassService>>hierarchyClassServiceFor:'.
+	classService := RowanClassService forClassNamed: 'RowanClassService'. 
+	self assert: (classService name isKindOf: String).
+	classService := RowanClassService forClassNamed: #RowanClassService.
+	self assert: (classService name isKindOf: String).
+
+	classService := RowanClassService forClassNamed: 'RowanClassService' meta: true. 
+	self assert: (classService name isKindOf: String).
+	classService := RowanClassService forClassNamed: #RowanClassService meta: true. 
+	self assert: (classService name isKindOf: String).
+
+	classService := RowanClassService basicForClassNamed: 'RowanClassService'.
+	self assert: (classService name isKindOf: String).
+	classService := RowanClassService basicForClassNamed: #RowanClassService.
+	self assert: (classService name isKindOf: String).
+
+	classService := RowanClassService forClassNamed: 'RowanClassService' package: 'Rowan-Services-Tests'. 
+	self assert: (classService name isKindOf: String).
+	classService := RowanClassService forClassNamed: #RowanClassService package: 'Rowan-Services-Tests'. 
+	self assert: (classService name isKindOf: String).
+
+	classService := RowanClassService minimalForClassNamed: 'RowanClassService'.
+	self assert: (classService name isKindOf: String).
+	classService := RowanClassService minimalForClassNamed: #RowanClassService.
+	self assert: (classService name isKindOf: String).
+]
+
 { #category : 'test method compilation' }
 RowanClassServiceTest >> test_selectedMethod [
 	| classService methodService selector |
@@ -185,10 +311,10 @@ RowanClassServiceTest >> test_setSuperSubIndicators [
 	subclassService saveMethodSource: selector asString,  ' ^#subclassMethod' category: 'abc'.
 	subclassMethodService := RowanCommandResult results 
 			detect:[:service | service isMethodService
-				and:[service selector = selector and:[service className = #RowanSubClass]]]. "an updated subclass method should be heading back to the client" 
+				and:[service selector = selector and:[service className = 'RowanSubClass']]]. "an updated subclass method should be heading back to the client" 
 	superclassMethodService := RowanCommandResult results 
 			detect:[:service | service isMethodService
-				and:[service selector = selector and:[service className = #RowanSample1]]]. "an updated superclass method should be heading back to the client" 
+				and:[service selector = selector and:[service className = 'RowanSample1']]]. "an updated superclass method should be heading back to the client" 
 	self assert: superclassMethodService hasSubs.  
 	self deny: superclassMethodService hasSupers.
 	self assert: subclassMethodService hasSupers.
@@ -279,99 +405,4 @@ RowanClassServiceTest >> test_simpleCompileWithoutMetaSet [
 	self assert: methodService first meta equals: false. "we created an instance method"
 	self assert: methodService first category equals: 'testing'.
 	self assert: (self servicesClassInstance perform: selector).
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testAddCategory [
-	| classService behavior |
-	
-	behavior := Rowan globalNamed: self servicesDefaultClassName. 
-	self deny: (behavior categoryNames includes: 'fnoodle'). 
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
-	classService addCategory: 'fnoodle'.
-	self assert: (behavior categoryNames includes: #fnoodle).
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testBehavior [
-	"return class or meta class" 
-	| classService |
-	classService := RowanClassService forClassNamed: 'Array' meta: false.
-	self assert: classService behavior equals: Array.
-	classService := RowanClassService forClassNamed: 'OrderedCollection' meta: true.
-	self assert: classService behavior equals: OrderedCollection class
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testClassComment [
-	| classService className behavior packageService |
-	behavior := Rowan globalNamed: self servicesDefaultClassName. 
-	self assert: behavior comment equals: String new. 
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName meta: false. 
-	classService classComment: 'This is a test'. 
-	self assert: behavior comment equals: 'This is a test'
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testClassFromName [
-	"always return thisClass" 
-	| classService |
-	classService := RowanClassService forClassNamed: 'Array' meta: false.
-	self assert: classService classFromName equals: Array.
-	classService := RowanClassService forClassNamed: 'OrderedCollection' meta: true.
-	self assert: classService classFromName equals: OrderedCollection
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testClassHierarchy [
-	"return class hierarchy in format client can use.
-	#nil -> #(Object class service)
-	Object class service -> #(RowanService class service) 
-	etc"
-  
-	| classService hierarchy objectClassService rowanServiceService |
-	classService := RowanClassService forClassNamed: 'RowanClassService'.
-	hierarchy := classService classHierarchy hierarchyServices. 
-	self assert: (hierarchy isKindOf: Dictionary). 
-	self assert: ((hierarchy at: #nil) isKindOf: Array).
-	self assert: (hierarchy at: #nil) size equals: 1. 
-	objectClassService := (hierarchy at: #nil) first.
-	self assert: (objectClassService isKindOf: RowanClassService).
-	self assert: objectClassService name equals: 'Object'.
-	rowanServiceService := (hierarchy at: objectClassService) first. 
-	self assert: rowanServiceService name equals: 'RowanService'.
-	self assert: (hierarchy at: rowanServiceService) first name equals: 'RowanClassService'.
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testClassHierarchyClassSide [
-	"same as instance side"
-  
-	| classService hierarchy objectClassService rowanServiceService |
-	classService := RowanClassService forClassNamed: 'RowanClassService' meta: true.
-	hierarchy := classService classHierarchy hierarchyServices. 
-	self assert: (hierarchy isKindOf: Dictionary). 
-	self assert: ((hierarchy at: #nil) isKindOf: Array).
-	self assert: (hierarchy at: #nil) size equals: 1. 
-	objectClassService := (hierarchy at: #nil) first.
-	self assert: (objectClassService isKindOf: RowanClassService).
-	self assert: objectClassService name equals: 'Object'.
-	rowanServiceService := (hierarchy at: objectClassService) first. 
-	self assert: rowanServiceService name equals: 'RowanService'.
-	self assert: (hierarchy at: rowanServiceService) first name equals: 'RowanClassService'.
-]
-
-{ #category : 'tests' }
-RowanClassServiceTest >> testEquality [
-
-	| classService1 classService2 |
-	classService1 := RowanClassService forClassNamed: 'RowanClassService'. 
-	classService2 := RowanClassService forClassNamed: 'RowanClassService'. 
-	self assert: classService1 equals: classService2.
-	self deny: classService1 == classService2.
-	self deny: classService1 equals: RowanClassService. 
-	self deny: classService1 equals: #foo.
-	self deny: classService1 equals: (RowanPackageService forPackageNamed: 'Rowan-Services-Tests').
-	self deny: classService1 equals: (RowanProjectService newNamed: 'Rowan').
-	self deny: classService1 equals: (RowanMethodService forSelector: #testEquality class: RowanClassServiceTest meta: false organizer: ClassOrganizer new)
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanDebuggerServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanDebuggerServiceTest.class.st
@@ -1,0 +1,83 @@
+Class {
+	#name : 'RowanDebuggerServiceTest',
+	#superclass : 'RowanServicesTest',
+	#category : 'Rowan-Services-Tests'
+}
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugBlanksOnly [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := '     '. 
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: 'nil halt.'
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugEmptyString [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := String new.
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: 'nil halt.'
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugStringBarInString [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := '| var |
+var := ''|'''. 
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: '| var | nil halt. 
+var := ''|'''.
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugStringLeadingWhitespace [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := '   | var |
+var := ''|'''. 
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: '| var | nil halt. 
+var := ''|'''.
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugStringNoTemps [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := 'abc'. 
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: 'nil halt. ', string
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_debugStringTemps [
+
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := '| ps |
+ps := RowanProjectService newNamed: ''RowanSample1''.
+ps refresh'. 
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: '| ps | nil halt. 
+ps := RowanProjectService newNamed: ''RowanSample1''.
+ps refresh'
+]
+
+{ #category : 'tests' }
+RowanDebuggerServiceTest >> test_malformed [
+	"it won't compile but it shouldn't walkback either"
+	| string debugString |
+	self jadeiteIssueTested: #issue262 withTitle: 'Console debug-it does nothing if selected expression has temp variables'.
+	string := 'abc | def | ^abc'.
+	debugString := RowanDebuggerService new debugStringFrom: string. 
+	self assert: debugString equals: 'nil halt. abc | def | ^abc'.
+]

--- a/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
@@ -93,6 +93,25 @@ RowanMethodServiceTest >> test_noStepPoints [
 ]
 
 { #category : 'tests' }
+RowanMethodServiceTest >> test_runMethodTest [
+
+	| methodService classService |
+	self jadeiteIssueTested: #issue410 withTitle: 'Selecting class in Project Browser changes test status icons in SUnit Browser'.
+	methodService := RowanMethodService new.
+	methodService runTest: #test_matchingPattern inClassName: 'RowanAnsweringServiceTest'.
+	self assert: methodService testResult equals: 'passed'.
+	self createServicesTestTestClass.
+	self loadServicesTestProject.
+	classService := RowanClassService forClassNamed: self servicesDefaultTestClassName.
+	classService saveMethodSource: 'testMethod1  self assert: false' category: 'failing test'.
+	methodService runTest: #testMethod1 inClassName: self servicesDefaultTestClassName.
+	self assert: methodService testResult equals: 'failure'.
+	classService saveMethodSource: 'testMethod2  1 zork' category: 'failing test'.
+	methodService runTest: #testMethod2 inClassName: self servicesDefaultTestClassName.
+	self assert: methodService testResult equals: 'error'.
+]
+
+{ #category : 'tests' }
 RowanMethodServiceTest >> test_stepPoint1 [
 	| classService methodService |
 	classService := RowanClassService forClassNamed: self servicesDefaultClassName.

--- a/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
@@ -84,6 +84,26 @@ RowanMethodServiceTest >> tearDown [
 ]
 
 { #category : 'tests' }
+RowanMethodServiceTest >> test_classNameIsString [
+
+	| methodService organizer |
+	self jadeiteIssueTested: #issue441 withTitle: '(3.0.62) suspicious code in RowanClassService>>hierarchyClassServiceFor:'.
+	organizer := ClassOrganizer new. 
+	methodService := RowanMethodService forGsNMethod: (RowanMethodServiceTest compiledMethodAt: #setUp) organizer: organizer.
+	self assert: (methodService className isKindOf: String).
+	self assert: methodService className = 'RowanMethodServiceTest'.
+
+	methodService := RowanMethodService forSelector: #setUp class: RowanMethodServiceTest meta: false organizer: organizer.
+	self assert: (methodService className isKindOf: String).
+	self assert: methodService className = 'RowanMethodServiceTest'.
+
+	methodService := RowanMethodService source: 'fnoodle' selector: #fnoodle category: 'other' className: 'RowanMethodServiceTest' packageName: 'Rowan-Services-Tests' meta: true. 
+	self assert: (methodService className isKindOf: String).
+	self assert: methodService className = 'RowanMethodServiceTest'.
+	System abortTransaction.
+]
+
+{ #category : 'tests' }
 RowanMethodServiceTest >> test_noStepPoints [
 	| classService methodService |
 	classService := RowanClassService forClassNamed: self servicesDefaultClassName.

--- a/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
@@ -1,0 +1,148 @@
+Class {
+	#name : 'RowanMethodServiceTest',
+	#superclass : 'RowanServicesTest',
+	#category : 'Rowan-Services-Tests'
+}
+
+{ #category : 'support' }
+RowanMethodServiceTest >> setUp [
+
+	super setUp.
+	self createServicesTestClass. 
+	self loadServicesTestProject.
+]
+
+{ #category : 'constants' }
+RowanMethodServiceTest >> stepPoint1Source [
+	"sent from the client, too" 
+
+^'simpleMethod
+
+	| array |
+	array := Array new. 
+						"^1"
+	array add: OrderedCollection new. 
+			"^3"							"^2"
+	array size.
+			"^4"
+	^array'
+]
+
+{ #category : 'constants' }
+RowanMethodServiceTest >> stepPoint2Source [
+	"sent from the client, too" 
+
+
+^'simpleMethod2
+
+	| array |
+	array := Array new. 
+						"^1"
+	array add: (RowanClassService forClassNamed: Fraction). 
+			"^3"								"^2"
+	array do:[:classService | 
+			"^4"  
+				| stepPoints |
+			stepPoints := classService stepPoints.
+												"^5"
+			stepPoints size
+							"^6"]. 
+	array size.
+			"^7"
+	^array'
+]
+
+{ #category : 'constants' }
+RowanMethodServiceTest >> stepPoint3Source [
+	"sent from the client, too" 
+
+	"missing step point numbers were optimized away or screwed
+	up by the 3.2.15 server. "
+
+^'initialize: aGsProcess status: aString
+
+	| theOrganizer frames oop status |
+	theOrganizer := ClassOrganizer new. 
+												"^1"
+	frames := Array new: aGsProcess stackDepth.
+							"^3"					"^2"
+	1 to: aGsProcess stackDepth do: [:i | 
+								"^4"
+		frames at: i put: (RowanFrameService process: aGsProcess level: i organizer: theOrganizer).
+				"^5"											"^6"
+	].
+	oop := aGsProcess asOop.  
+								"^9"
+	status := aString.'
+]
+
+{ #category : 'support' }
+RowanMethodServiceTest >> tearDown [
+
+	super tearDown.
+	self unloadServicesTestProject
+]
+
+{ #category : 'tests' }
+RowanMethodServiceTest >> test_noStepPoints [
+	| classService methodService |
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService saveMethodSource: 'abc' category: 'testing step points'.
+	methodService := RowanMethodService forSelector: #abc class: classService classOrMeta meta: false organizer: ClassOrganizer new.
+	self assert: methodService stepPoints isEmpty.
+]
+
+{ #category : 'tests' }
+RowanMethodServiceTest >> test_stepPoint1 [
+	| classService methodService |
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService saveMethodSource: self stepPoint1Source category: 'testing step points'.
+	methodService := RowanMethodService forSelector: #simpleMethod class: classService classOrMeta meta: false organizer: ClassOrganizer new.
+	self assert: methodService stepPoints size equals: 4.		
+	self assert: (methodService source copyFrom: 42 to: 44) asSymbol equals: (methodService stepPoints at: 1) value. "#new"
+	self assert: (methodService source copyFrom: 89 to: 91) asSymbol equals: (methodService stepPoints at: 2) value. "#new"
+	self assert: (methodService source copyFrom: 66 to: 69) asSymbol equals: (methodService stepPoints at: 3) value. "#add:"
+	self assert: (methodService source copyFrom: 121 to: 124) asSymbol equals: (methodService stepPoints at: 4) value. "#size"
+]
+
+{ #category : 'tests' }
+RowanMethodServiceTest >> test_stepPoint2 [
+	| classService methodService |
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService saveMethodSource: self stepPoint2Source category: 'testing step points'.
+	methodService := RowanMethodService forSelector: #simpleMethod2 class: classService classOrMeta meta: false organizer: ClassOrganizer new.
+	self assert: methodService stepPoints size equals: 7.		
+	self assert: (methodService source copyFrom: 43 to: 45) asSymbol equals: (methodService stepPoints at: 1) value. "#new"
+	self assert: (methodService source copyFrom: 91 to: 104) asSymbol equals: (methodService stepPoints at: 2) value. "#forClassNamed:"
+	self assert: (methodService source copyFrom: 67 to: 70) asSymbol equals: (methodService stepPoints at: 3) value. "#add:"
+	self assert: (methodService source copyFrom: 145 to: 147) asSymbol equals: (methodService stepPoints at: 4) value. "#do:"
+	self assert: (methodService source copyFrom: 295 to: 298) asSymbol equals: (methodService stepPoints at: 5) value. "#size"
+	self assert: (methodService source copyFrom: 225 to: 234) asSymbol equals: (methodService stepPoints at: 6) value. "#stepPoints"
+	self assert: (methodService source copyFrom: 268 to: 271) asSymbol equals: (methodService stepPoints at: 7) value. "#size"
+]
+
+{ #category : 'tests' }
+RowanMethodServiceTest >> test_stepPoint3 [
+	| classService methodService |
+	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
+	classService saveMethodSource: self stepPoint3Source category: 'testing step points'.
+	methodService := RowanMethodService forSelector: #'initialize:status:' class: classService classOrMeta meta: false organizer: ClassOrganizer new.
+	self assert: methodService stepPoints size equals: 9.		
+	self assert: (methodService source copyFrom: 109 to: 111) asSymbol equals: (methodService stepPoints at: 1) value. 
+	self assert: (methodService stepPoints at: 1) value equals: #new.
+	self assert: (methodService source copyFrom: 165 to: 174) asSymbol equals: (methodService stepPoints at: 2) value.
+	self assert: (methodService stepPoints at: 2) value equals: #stackDepth.
+	self assert: (methodService source copyFrom: 149 to: 152) asSymbol equals: (methodService stepPoints at: 3) value. 
+	self assert: (methodService stepPoints at: 3) value equals: #new:.
+	self assert: (methodService source copyFrom: 216 to: 225) asSymbol equals: (methodService stepPoints at: 4) value. 
+	self assert: (methodService stepPoints at: 4) value equals: #stackDepth.
+	self assert: (methodService source copyFrom: 290 to: 297) asSymbol equals: #process:. 
+	self assert: (methodService stepPoints at: 5) value equals: #'process:level:organizer:'. 
+	self assert: (methodService source copyFrom: 260 to: 262) asSymbol equals: #at:. 		
+	self assert: (methodService stepPoints at: 6) value equals: #at:put:.
+
+	"7 & 8 are present in 3.2.15 but are incorrect presumably due to optimization. Later server versions may get this fixed"
+	
+	self assert: (methodService source copyFrom: 392 to: 396) asSymbol equals: (methodService stepPoints at: 9) value. "#asOop"
+self assert: (methodService stepPoints at: 9) value equals: #asOop.
+]

--- a/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
@@ -46,9 +46,9 @@ RowanPackageServiceTest >> test_compileAndSelectClassDifferentPackage [
 		category: ''Rowan-Services-Tests''
 		options: #()'.
 	self assert: RowanCommandResult results size equals: 2. 
-	self assert: RowanCommandResult results first name equals: 'RowanTestCompile'. 
-	self assert: RowanCommandResult results last name equals: 'Rowan-Services-Tests'. 
-	testsPackage := RowanCommandResult results last.
+	self assert: RowanCommandResult results last name equals: 'RowanTestCompile'. 
+	self assert: RowanCommandResult results first name equals: 'Rowan-Services-Tests'. 
+	testsPackage := RowanCommandResult results first.
 	self assert: testsPackage selectedClass name equals: 'RowanTestCompile'.
 	self assert: testsPackage selectedClass selectedPackageServices first equals: testsPackage] 
 		ensure:[System abortTransaction.  "get rid of test package and class"]

--- a/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
@@ -5,6 +5,69 @@ Class {
 }
 
 { #category : 'tests' }
+RowanPackageServiceTest >> test_compileAndSelectClass [
+
+	| package packageService |
+	System commitTransaction.
+	[self assert: RowanCommandResult results isEmpty. 
+	package := self createJadeiteTestPackage. 
+	packageService := RowanPackageService forPackageNamed: self servicesTestPackageName.
+	self assert: RowanCommandResult results isEmpty. 
+	packageService compileClass: 
+	'RowanServicesTest rwSubclass: ''RowanTestCompile'' 
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: ''', self servicesTestPackageName,  '''
+		options: #()'.
+	self assert: RowanCommandResult results size equals: 1. 
+	self assert: RowanCommandResult results first name equals: 'RowanTestCompile'. 
+	self assert: packageService selectedClass name equals: 'RowanTestCompile'.
+	self assert: packageService selectedClass selectedPackageServices first equals: packageService] 
+		ensure:[System abortTransaction.  "get rid of test package and class"]
+]
+
+{ #category : 'tests' }
+RowanPackageServiceTest >> test_compileAndSelectClassDifferentPackage [
+
+	| package packageService testsPackage |
+	System commitTransaction.
+	[self assert: RowanCommandResult results isEmpty. 
+	package := self createJadeiteTestPackage. 
+	packageService := RowanPackageService forPackageNamed: self servicesTestPackageName.
+	self assert: RowanCommandResult results isEmpty. 
+	packageService compileClass: 
+	'RowanServicesTest rwSubclass: ''RowanTestCompile''
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: ''Rowan-Services-Tests''
+		options: #()'.
+	self assert: RowanCommandResult results size equals: 2. 
+	self assert: RowanCommandResult results first name equals: 'RowanTestCompile'. 
+	self assert: RowanCommandResult results last name equals: 'Rowan-Services-Tests'. 
+	testsPackage := RowanCommandResult results last.
+	self assert: testsPackage selectedClass name equals: 'RowanTestCompile'.
+	self assert: testsPackage selectedClass selectedPackageServices first equals: testsPackage] 
+		ensure:[System abortTransaction.  "get rid of test package and class"]
+]
+
+{ #category : 'tests' }
+RowanPackageServiceTest >> test_packageWasDeleted [
+
+	| package packageService |
+	System commitTransaction. 
+	self jadeiteIssueTested: #issue284 withTitle: '(3.0.49 and 3.0.50) project browser not updated properly on reload of project'.
+	package := self createJadeiteTestPackage. 
+	packageService := RowanPackageService forPackageNamed: self servicesTestPackageName.
+	self deny: packageService wasDeleted.
+	System abortTransaction. 
+	self assert: packageService wasDeleted.
+]
+
+{ #category : 'tests' }
 RowanPackageServiceTest >> testClassHierarchy [
 
 	"format for client is:
@@ -33,20 +96,20 @@ RowanPackageServiceTest >> testCompileClassSelectsPackageAndClass [
 
 	self jadeiteIssueTested: #issue228 withTitle: 'lose selected class in project browser when new version created'.
 	package := self createJadeiteTestPackage. 
-	[packageService := RowanPackageService forPackageNamed: self jadeiteTestPackageName.
+	[packageService := RowanPackageService forPackageNamed: self servicesTestPackageName.
 	packageService compileClass: 
 		'RowanServicesTest rwSubclass: ''TestCompileClass''
 			instVarNames: #()
 			classVars: #()
 			classInstVars: #()
 			poolDictionaries: #()
-			category: ''', self jadeiteTestPackageName, '''
+			category: ''', self servicesTestPackageName, '''
 			options: #()'.
-	self assert: RowanCommandResult results size equals: 2.
-	newClassService := RowanCommandResult results detect:[:service | service name = 'TestCompileClass'] ifNone:[]. 
+	self assert: RowanCommandResult results size equals: 1.
+	newClassService := RowanCommandResult results first.
 	self assert: newClassService name equals: 'TestCompileClass'. 
 	self assert: newClassService selectedPackageServices size equals: 1. 
-	self assert: newClassService selectedPackageServices first name equals: self jadeiteTestPackageName. 
+	self assert: newClassService selectedPackageServices first name equals: self servicesTestPackageName. 
 	self assert: newClassService selectedPackageServices first selectedClass == newClassService]
-		ensure:[RowanBrowserService new unloadProjectsNamed: (Array with: self jadeiteTestProjectName)]
+		ensure:[RowanBrowserService new unloadProjectsNamed: (Array with: self servicesTestProjectName)]
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
@@ -34,7 +34,7 @@ RowanProjectServiceTest >> setUp [
 RowanProjectServiceTest >> tearDown [
 
 	super tearDown.
-	self unloadDefaultProject
+	self unloadServicesTestProject
 ]
 
 { #category : 'tests' }
@@ -56,11 +56,11 @@ RowanProjectServiceTest >> test_addPackage [
 
 	| projectService  packageName loadedPackage |
 	packageName := 'TestAddPackage'.
-	projectService := self projectServiceNamed: self defaultProjectName.
+	projectService := self projectServiceNamed: self servicesTestProjectName.
 	projectService addPackageNamed: packageName.
 	loadedPackage := Rowan image loadedPackageNamed: packageName.
 	self assert: loadedPackage name equals: packageName. 
-	self assert: loadedPackage projectName equals: self defaultProjectName
+	self assert: loadedPackage projectName equals: self servicesTestProjectName
 ]
 
 { #category : 'tests' }
@@ -72,7 +72,7 @@ RowanProjectServiceTest >> test_commandResultSessionTemp [
 { #category : 'tests' }
 RowanProjectServiceTest >> test_updateAddsCommandResult [
 	| projectService |
-	projectService := self projectServiceNamed: self defaultProjectName.
+	projectService := self projectServiceNamed: self servicesTestProjectName.
 	RowanCommandResult initializeResults. 
 	self assert: RowanCommandResult results size equals: 0. 
 	projectService update. 

--- a/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
@@ -26,8 +26,8 @@ RowanProjectServiceTest >> projectServiceNamed: projectName [
 RowanProjectServiceTest >> setUp [
 
 	super setUp.
-	self createDefaultProject.
-	self loadDefaultProject.
+	self createServicesTestProject.
+	self loadServicesTestProject.
 ]
 
 { #category : 'setup teardown' }

--- a/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanProjectServiceTest.class.st
@@ -43,11 +43,11 @@ RowanProjectServiceTest >> test_addedProjectNotOnDisk [
 	| proj projectService projectName |
 	projectName := 'Tashkent'. 
 	self jadeiteIssueTested: #issue246 withTitle: 'Jadeite handling project that''s not committed'. 
-	proj := RowanTestService new createNewTestProjectNamed: projectName.
+	self createNonDiskTestProjectNamed:  projectName packageName: 'Packagekent'. 
 	projectService := RowanProjectService newNamed: projectName. 
 	projectService refresh. "<-- walkback occured here" 
 	[self deny: projectService existsOnDisk.
-	self assert: projectService isSkew]
+	self deny: projectService isSkew "no skew if not on disk"]
 		ensure: [RowanBrowserService new unloadProjectsNamed: (Array with: 'Tashkent')]
 ]
 
@@ -67,6 +67,15 @@ RowanProjectServiceTest >> test_addPackage [
 RowanProjectServiceTest >> test_commandResultSessionTemp [
 
 	self assert: RowanCommandResult results == (SessionTemps current at: #rowanCommandResults)
+]
+
+{ #category : 'tests' }
+RowanProjectServiceTest >> test_unloadNotLoadedProjectDoesNotWalkback [
+
+	"just make sure if a project we gracefully handle trying to remove an unloaded project"
+	self deny: (Rowan image loadedProjectNamed: 'BadProjectName' ifAbsent:[false]). 
+	RowanBrowserService new unloadProjectsNamed: #('BadProjectName').
+	self deny: (Rowan image loadedProjectNamed: 'BadProjectName' ifAbsent:[false]).
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
@@ -34,11 +34,11 @@ RowanQueryServicesTest >> test_hierarchyImplementorsGetsAllSubclasses [
 		subclassesImplementing add:  methodService className.
 		classService classHierarchy. 
 		self assert: (classService classHierarchyNames includes: 'RwLoadedThing')].
-	self assert: (subclassesImplementing includes: #RwLoadedThing). 
-	self assert: (subclassesImplementing includes: #RwLoadedProject). 
-	self assert: (subclassesImplementing includes: #RwGsLoadedSymbolDictPackage). 
-	self assert: (subclassesImplementing includes: #RwGsLoadedSymbolDictClass). 
-	self assert: (subclassesImplementing includes: #RwGsLoadedSymbolDictClassExtension).
+	self assert: (subclassesImplementing includes: 'RwLoadedThing'). 
+	self assert: (subclassesImplementing includes: 'RwLoadedProject'). 
+	self assert: (subclassesImplementing includes: 'RwGsLoadedSymbolDictPackage'). 
+	self assert: (subclassesImplementing includes: 'RwGsLoadedSymbolDictClass'). 
+	self assert: (subclassesImplementing includes: 'RwGsLoadedSymbolDictClassExtension').
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
@@ -66,6 +66,17 @@ RowanQueryServicesTest >> test_implementors [
 ]
 
 { #category : 'tests' }
+RowanQueryServicesTest >> test_projectLog [
+
+	| queryService result |
+	queryService := RowanQueryService new.
+	queryService projectLog: 'Rowan'. 
+	result := RowanCommandResult results first. 
+	self assert: (result isKindOf: RowanQueryService). 
+	self assert: (result queryResults isKindOf: String)
+]
+
+{ #category : 'tests' }
 RowanQueryServicesTest >> test_senders [
 
 	| queryService hierarchyClassNames |

--- a/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
@@ -32,7 +32,7 @@ RowanServicesTest >> createDefaultClass [
 
 	| packageDefinition classDefinition |
 	packageDefinition := self createDefaultPackage.
-	classDefinition := self createClassDefinitionNamed: self defaultClassName. 
+	classDefinition := self createClassDefinitionNamed: self servicesDefaultClassName. 
 	packageDefinition addClassDefinition: classDefinition. 
 	^classDefinition
 ]
@@ -42,14 +42,14 @@ RowanServicesTest >> createDefaultPackage [
 
 	| projectDefinition |
 	projectDefinition := self createDefaultProject. 
-	projectDefinition addPackageNamed: self defaultPackageName.
-	^projectDefinition packageNamed: self defaultPackageName
+	projectDefinition addPackageNamed: self servicesTestPackageName.
+	^projectDefinition packageNamed: self servicesTestPackageName
 ]
 
 { #category : 'support' }
 RowanServicesTest >> createDefaultProject [
 
-	defaultProjectDefinition := self createProjectDefinitionNamed: self defaultProjectName.
+	defaultProjectDefinition := self createProjectDefinitionNamed: self servicesTestProjectName.
 	^defaultProjectDefinition
 ]
 
@@ -57,7 +57,7 @@ RowanServicesTest >> createDefaultProject [
 RowanServicesTest >> createJadeiteTestPackage [
 	| proj pkg |
 	proj := self createJadeiteTestProject. 
-	pkg := RwPackageDefinition newNamed: self jadeiteTestPackageName.
+	pkg := RwPackageDefinition newNamed: self servicesTestPackageName.
 	proj addPackage: pkg.
 	Rowan projectTools load loadProjectDefinition: proj.
 	^pkg.
@@ -66,8 +66,8 @@ RowanServicesTest >> createJadeiteTestPackage [
 { #category : 'support' }
 RowanServicesTest >> createJadeiteTestProject [
 	| proj |
-	proj := RwProjectDefinition newForGitBasedProjectNamed: self jadeiteTestProjectName. 
-	proj repositoryRootPath: '$ROWAN_PROJECTS_HOME/', self jadeiteTestProjectName. 
+	proj := RwProjectDefinition newForGitBasedProjectNamed: self servicesTestProjectName. 
+	proj repositoryRootPath: '$ROWAN_PROJECTS_HOME/', self servicesTestProjectName. 
 	Rowan projectTools create createProjectFor: proj.
 	^proj
 ]
@@ -84,28 +84,10 @@ RowanServicesTest >> createProjectDefinitionNamed: projectName [
 	^projectDefinition
 ]
 
-{ #category : 'constants' }
-RowanServicesTest >> defaultClassName [
-
-	^'ServicesTestClass'
-]
-
-{ #category : 'constants' }
-RowanServicesTest >> defaultPackageName [
-
-	^'ServicesTestPackage'
-]
-
 { #category : 'support' }
 RowanServicesTest >> defaultProjectDefinition [
 
 	^defaultProjectDefinition ifNil:[defaultProjectDefinition := self createDefaultProject]
-]
-
-{ #category : 'constants' }
-RowanServicesTest >> defaultProjectName [
-
-	^'ServicesTestProject'
 ]
 
 { #category : 'support' }
@@ -124,18 +106,6 @@ RowanServicesTest >> jadeiteIssueTested: aSymbol withTitle: anObject [
 		https://github.com/GemTalk/Jadeite/issues/"
 ]
 
-{ #category : 'constants' }
-RowanServicesTest >> jadeiteTestPackageName [
-
-	^'JadeitePackage'
-]
-
-{ #category : 'constants' }
-RowanServicesTest >> jadeiteTestProjectName [
-
-	^'JadeiteProject'
-]
-
 { #category : 'support' }
 RowanServicesTest >> loadDefaultProject [
 	
@@ -144,6 +114,24 @@ RowanServicesTest >> loadDefaultProject [
 	projectSetDefinition:= RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: self defaultProjectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+]
+
+{ #category : 'constants' }
+RowanServicesTest >> servicesDefaultClassName [
+
+	^'RowanServicesTestClass'
+]
+
+{ #category : 'constants' }
+RowanServicesTest >> servicesTestPackageName [
+
+	^'RowanServicesTestPackage'
+]
+
+{ #category : 'constants' }
+RowanServicesTest >> servicesTestProjectName [
+
+	^'RowanServicesTestProject'
 ]
 
 { #category : 'setup teardown' }
@@ -160,7 +148,8 @@ RowanServicesTest >> tearDown [
 ]
 
 { #category : 'support' }
-RowanServicesTest >> unloadDefaultProject [
+RowanServicesTest >> unloadServicesTestProject [
 
-	Rowan projectTools delete deleteProjectNamed: self defaultProjectName
+	Rowan image loadedProjectNamed: self servicesTestProjectName ifAbsent:[^self].
+	Rowan projectTools delete deleteProjectNamed: self servicesTestProjectName
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
@@ -47,6 +47,21 @@ RowanServicesTest >> createJadeiteTestProject [
 ]
 
 { #category : 'support' }
+RowanServicesTest >> createNonDiskTestProjectNamed: projectName packageName: packageName [
+
+	| projectDefinition projectSetDefinition  |
+	projectDefinition := RwProjectDefinition newForGitBasedProjectNamed: projectName.
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		yourself.
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+	^projectDefinition
+]
+
+{ #category : 'support' }
 RowanServicesTest >> createProjectDefinitionNamed: projectName [
 
 	| projectDefinition |
@@ -98,6 +113,35 @@ RowanServicesTest >> jadeiteIssueTested: aSymbol withTitle: anObject [
 
 	Issues currently reside in: 
 		https://github.com/GemTalk/Jadeite/issues/"
+]
+
+{ #category : 'support' }
+RowanServicesTest >> loadRowanSample1 [
+	| specUrlString projectTools rowanSpec gitRootPath projectName projectDefinition spec |
+
+	projectName := 'RowanSample1'.
+	(Rowan image loadedProjectNamed: projectName ifAbsent: [])
+		ifNotNil: [ :prj |  Rowan image _removeLoadedProject: prj ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := 'file:' , rowanSpec repositoryRootPath , '/samples/RowanSample1.ston'.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	spec := specUrlString asRwUrl asSpecification.
+	projectTools clone
+		cloneSpecification: spec
+		gitRootPath: gitRootPath
+		useSsh: true
+		registerProject: false.	"does not register the project, so it is not visible in project list ... does however clone the project to local disk"
+	
+	"attach a project definition to the Rowan project on disk ... not loaded and not registered"
+	projectDefinition := projectTools create createProjectFromSpecUrl: 'file:', gitRootPath, '/', projectName, '/', spec specsPath, '/RowanSample1.ston'.
+	Rowan projectTools load loadProjectNamed: 'RowanSample1'.
 ]
 
 { #category : 'support' }

--- a/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
@@ -28,32 +28,6 @@ RowanServicesTest >> createClassDefinitionNamed: className [
 ]
 
 { #category : 'support' }
-RowanServicesTest >> createDefaultClass [
-
-	| packageDefinition classDefinition |
-	packageDefinition := self createDefaultPackage.
-	classDefinition := self createClassDefinitionNamed: self servicesDefaultClassName. 
-	packageDefinition addClassDefinition: classDefinition. 
-	^classDefinition
-]
-
-{ #category : 'support' }
-RowanServicesTest >> createDefaultPackage [
-
-	| projectDefinition |
-	projectDefinition := self createDefaultProject. 
-	projectDefinition addPackageNamed: self servicesTestPackageName.
-	^projectDefinition packageNamed: self servicesTestPackageName
-]
-
-{ #category : 'support' }
-RowanServicesTest >> createDefaultProject [
-
-	defaultProjectDefinition := self createProjectDefinitionNamed: self servicesTestProjectName.
-	^defaultProjectDefinition
-]
-
-{ #category : 'support' }
 RowanServicesTest >> createJadeiteTestPackage [
 	| proj pkg |
 	proj := self createJadeiteTestProject. 
@@ -85,9 +59,29 @@ RowanServicesTest >> createProjectDefinitionNamed: projectName [
 ]
 
 { #category : 'support' }
-RowanServicesTest >> defaultProjectDefinition [
+RowanServicesTest >> createServicesTestClass [
 
-	^defaultProjectDefinition ifNil:[defaultProjectDefinition := self createDefaultProject]
+	| packageDefinition classDefinition |
+	packageDefinition := self createServicesTestPackage.
+	classDefinition := self createClassDefinitionNamed: self servicesDefaultClassName. 
+	packageDefinition addClassDefinition: classDefinition. 
+	^classDefinition
+]
+
+{ #category : 'support' }
+RowanServicesTest >> createServicesTestPackage [
+
+	| projectDefinition |
+	projectDefinition := self createServicesTestProject. 
+	projectDefinition addPackageNamed: self servicesTestPackageName.
+	^projectDefinition packageNamed: self servicesTestPackageName
+]
+
+{ #category : 'support' }
+RowanServicesTest >> createServicesTestProject [
+
+	defaultProjectDefinition := self createProjectDefinitionNamed: self servicesTestProjectName.
+	^defaultProjectDefinition
 ]
 
 { #category : 'support' }
@@ -107,12 +101,12 @@ RowanServicesTest >> jadeiteIssueTested: aSymbol withTitle: anObject [
 ]
 
 { #category : 'support' }
-RowanServicesTest >> loadDefaultProject [
+RowanServicesTest >> loadServicesTestProject [
 	
 	| projectSetDefinition |
 
 	projectSetDefinition:= RwProjectSetDefinition new.
-	projectSetDefinition addDefinition: self defaultProjectDefinition.
+	projectSetDefinition addDefinition: self servicesTestProjectDefinition.
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 ]
 
@@ -126,6 +120,12 @@ RowanServicesTest >> servicesDefaultClassName [
 RowanServicesTest >> servicesTestPackageName [
 
 	^'RowanServicesTestPackage'
+]
+
+{ #category : 'support' }
+RowanServicesTest >> servicesTestProjectDefinition [
+
+	^defaultProjectDefinition ifNil:[defaultProjectDefinition := self createServicesTestProject]
 ]
 
 { #category : 'constants' }

--- a/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
@@ -100,6 +100,33 @@ RowanServicesTest >> createServicesTestProject [
 ]
 
 { #category : 'support' }
+RowanServicesTest >> createServicesTestTestClass [
+
+	| packageDefinition classDefinition |
+	packageDefinition := defaultProjectDefinition packageNamed: self servicesTestPackageName. 
+	classDefinition := self createTestClassDefinitionNamed: self servicesDefaultTestClassName. 
+	packageDefinition addClassDefinition: classDefinition. 
+	^classDefinition
+]
+
+{ #category : 'support' }
+RowanServicesTest >> createTestClassDefinitionNamed: className [
+
+	| classDefinition |
+	classDefinition := RwClassDefinition
+		newForClassNamed: className
+			super: 'TestCase'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: 'services test'
+			comment: String new
+			pools: #()
+			type: 'normal'.
+	^classDefinition
+]
+
+{ #category : 'support' }
 RowanServicesTest >> defaultSymbolDictionaryName [
 
 	^'ServicesTestDictionary'
@@ -158,6 +185,12 @@ RowanServicesTest >> loadServicesTestProject [
 RowanServicesTest >> servicesDefaultClassName [
 
 	^'RowanServicesTestClass'
+]
+
+{ #category : 'constants' }
+RowanServicesTest >> servicesDefaultTestClassName [
+
+	^'RowanServicesTestClassForTesting'
 ]
 
 { #category : 'constants' }

--- a/rowan/src/Rowan-Services-Tests/RowanTestClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanTestClassServiceTest.class.st
@@ -4,6 +4,40 @@ Class {
 	#category : 'Rowan-Services-Tests'
 }
 
+{ #category : 'support' }
+RowanTestClassServiceTest class >> shouldInheritSelectors [
+
+	^true
+]
+
+{ #category : 'support' }
+RowanTestClassServiceTest >> nonTestMethod [
+
+	"do not remove. Used in test"
+]
+
+{ #category : 'tests' }
+RowanTestClassServiceTest >> test_isTestCase [
+
+	| classService |
+	self jadeiteIssueTested: #issue253 withTitle: 'popup method menu in method list is slow for JadeServer methods'. 
+	classService := RowanClassService forClassNamed: self class.
+	self assert: classService isTestCase.
+	classService isTestCase: false. 
+	self deny: classService isTestCase. 
+	classService setIsTestCaseCommand. 
+	self assert: classService isTestCase.
+
+	classService := RowanClassService forClassNamed: 'JadeServer'.
+	self deny: classService isTestCase.
+]
+
+{ #category : 'tests' }
+RowanTestClassServiceTest >> test_runClassService [
+
+	self jadeiteIssueTested: #issue341 withTitle: 'Run sunit tests from class pass when they should not'.
+]
+
 { #category : 'tests' }
 RowanTestClassServiceTest >> test_setTestClass [
 
@@ -17,4 +51,14 @@ RowanTestClassServiceTest >> test_setTestClass [
 	self assert: classService isTestCase equals: nil.
 	classService setIsTestCase. 
 	self assert: classService isTestCase.
+]
+
+{ #category : 'tests' }
+RowanTestClassServiceTest >> test_testSelectors [
+
+	| classService |
+	self jadeiteIssueTested: #issue341 withTitle: 'Run sunit tests from class pass when they should not'.
+	classService := RowanClassService forClassNamed: 'RowanTestClassServiceTest'. 
+	self deny: (classService tests detect:[:methodService | methodService selector = #test_testSelectors] ifNone:[]) equals: nil.
+	self assert: (classService tests detect:[:methodService | methodService selector = #nonTestMethod] ifNone:[]) equals: nil.
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanTestClassServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanTestClassServiceTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'RowanTestClassServiceTest',
+	#superclass : 'RowanClassServiceTest',
+	#category : 'Rowan-Services-Tests'
+}
+
+{ #category : 'tests' }
+RowanTestClassServiceTest >> test_setTestClass [
+
+	| classService |
+	classService := RowanClassService new name:  'RowanMethodService'. 
+	self assert: classService isTestCase equals: nil.
+	classService setIsTestCase. 
+	self deny: classService isTestCase. 
+	
+	classService := RowanClassService new name:  'RowanTestClassServiceTest'. 
+	self assert: classService isTestCase equals: nil.
+	classService setIsTestCase. 
+	self assert: classService isTestCase.
+]

--- a/rowan/src/Rowan-Tests/RwAbstractTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAbstractTest.class.st
@@ -279,6 +279,28 @@ RwAbstractTest >> classExtensionDefinition: className instanceMethods: instanceM
 		yourself
 ]
 
+{ #category : 'private' }
+RwAbstractTest >> gsInteractionConfirmationHandler [
+
+	^ GsInteractionHandler new
+		defaultBlock: [ :ignored | self assert: false description: 'expected a confirmation' ];
+		confirmBlock: [ :interaction | interaction ok ];
+		yourself
+]
+
+{ #category : 'private' }
+RwAbstractTest >> handleConfirmationDuring: aBlock [
+
+	"expect a confirmation"
+
+	aBlock
+		on: GsInteractionRequest
+		do: [ :ex | 
+			ex
+				response:
+					(ex interaction interactWith: self gsInteractionConfirmationHandler) ]
+]
+
 { #category : 'support' }
 RwAbstractTest >> methodDefsFromSpec: specArray [
   | dict |

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -170,6 +170,146 @@ RwAdoptToolApiTest >> testAdoptMethod [
 ]
 
 { #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_A [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"adopt methods without changing protocol to use hybrid convention"
+
+	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod symbolList audit |
+	projectName := 'AdoptProject'.
+	packageName1 := 'Adopt-Core'.
+	packageName2 := 'Adopt-Extension'.
+	packageNames := {packageName1. packageName2 }.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+	symbolList := Rowan image symbolList.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use non-Rowan api to create class and methods"
+	theClass := Object subclass: className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: symDict
+		options: #().
+
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptClassNamed: className  
+			intoPackageNamed: packageName1.
+
+	instanceMethod := theClass
+		compileMethod: 'foo ^''foo'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+	classMethod := theClass class
+		compileMethod: 'bar ^''bar'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+	self assert: instanceMethod rowanProjectName = Rowan unpackagedName.
+	self assert: classMethod rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptMethod: #foo 
+			inClassNamed: className  
+			isMeta: false 
+			intoPackageNamed: packageName2;
+		adoptMethod: #bar 
+			inClassNamed: className  
+			isMeta: true 
+			intoPackageNamed: packageName2;
+		yourself.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName2.
+	self assert: classMethod rowanPackageName = packageName2.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+]
+
+{ #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_B [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"adopt methods without changing protocol to use hybrid convention"
+
+	| projectName packageNames className packageName theClass symDict symDictName instanceMethod classMethod symbolList audit |
+	projectName := 'AdoptProject'.
+	packageName := 'Adopt-Core'.
+	packageNames := {packageName}.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+	symbolList := Rowan image symbolList.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use non-Rowan api to create class and methods"
+	theClass := Object subclass: className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: symDict
+		options: #().
+
+	instanceMethod := theClass
+		compileMethod: 'foo ^''foo'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+	classMethod := theClass class
+		compileMethod: 'bar ^''bar'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+	self assert: instanceMethod rowanProjectName = Rowan unpackagedName.
+	self assert: classMethod rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptMethod: #foo 
+			inClassNamed: className  
+			isMeta: false 
+			intoPackageNamed: packageName;
+		adoptMethod: #bar 
+			inClassNamed: className  
+			isMeta: true 
+			intoPackageNamed: packageName;
+		yourself.
+
+"validate"
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+	self assert: instanceMethod rowanProjectName = projectName.
+	self assert: classMethod rowanProjectName = projectName.
+
+"audit --> category not correct"
+	self deny: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+]
+
+{ #category : 'tests' }
 RwAdoptToolApiTest >> testAdoptSymbolDictionary_1 [
 
 	"simplest case"

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -16,7 +16,8 @@ RwAdoptToolApiTest >> _validateExpectedMonticelloConventionFailure_389_A: audit 
 	"class category not following Monticello conventions"
 	unexpectedFailures := ((audit at: (packageNames at: 1)) at: className)
 		reject: [:each | (each value = 'Class category has changed in compiled class v loaded class')
-			or: [ (each value = 'Missing instance method extension category ') or: [ each value = 'Missing class method extension category ' ] ] ].
+			or: [ (each value = 'Missing instance method extension category ') or: [ (each value = 'Missing class method extension category ')
+			or: [ (each value = 'Missing loaded instance method. ') or: [ (each value = 'Missing loaded classmethod ') ]] ] ] ].
 	self assert: unexpectedFailures isEmpty
 ]
 

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -4,6 +4,48 @@ Class {
 	#category : 'Rowan-Tests'
 }
 
+{ #category : 'private' }
+RwAdoptToolApiTest >> _validateExpectedMonticelloConventionFailure_389_A: audit packageNames: packageNames className: className [
+
+	"validate expected audit failures - according to Monticello conventions"
+
+	| unexpectedFailures |
+	self _validateExpectedMonticelloConventionFailure_389: audit packageName: (packageNames at: 2) className: className.
+	audit removeKey: (packageNames at: 2).
+
+	"class category not following Monticello conventions"
+	unexpectedFailures := ((audit at: (packageNames at: 1)) at: className)
+		reject: [:each | (each value = 'Class category has changed in compiled class v loaded class')
+			or: [ (each value = 'Missing instance method extension category ') or: [ each value = 'Missing class method extension category ' ] ] ].
+	self assert: unexpectedFailures isEmpty
+]
+
+{ #category : 'private' }
+RwAdoptToolApiTest >> _validateExpectedMonticelloConventionFailure_389_B: audit packageName: packageName className: className [
+
+	"validate expected audit failures - according to Monticello conventions"
+
+	self _validateExpectedMonticelloConventionFailure_389: audit packageName: packageName className: className.
+	audit removeKey: packageName.
+	self assert: audit isEmpty
+]
+
+{ #category : 'private' }
+RwAdoptToolApiTest >> _validateExpectedMonticelloConventionFailure_389: audit packageName: packageName className: className [
+
+	"validate expected audit failures - according to Monticello conventions"
+
+	| failures unexpectedFailures |
+	failures := audit at: packageName.
+	self assert: failures size = 1.
+	failures := failures at: className.
+	self assert: failures size = 2.
+
+	"extension categories not named according to Monticello conventions (no leading $*)"
+	unexpectedFailures := failures reject: [:each | (each value = 'Missing instance method extension category ') or: [ each value = 'Missing class method extension category ' ] ].
+	self assert: unexpectedFailures isEmpty
+]
+
 { #category : 'tests' }
 RwAdoptToolApiTest >> testAdoptClass [
 	| projectName packageNames className packageName theClass symDict symDictName instanceMethod classMethod symbolList |
@@ -174,7 +216,9 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_A [
 
 	"https://github.com/GemTalk/Rowan/issues/389"
 
-	"adopt methods without changing protocol to use hybrid convention"
+	"adopt methods into a different package than the packaged class; 
+		don't use use Monticello convention.
+	 methods should be extension methods."
 
 	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod symbolList audit |
 	projectName := 'AdoptProject'.
@@ -238,8 +282,10 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_A [
 	self assert: instanceMethod rowanPackageName = packageName2.
 	self assert: classMethod rowanPackageName = packageName2.
 
-"audit"
-	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+"audit --> category not correct according to Monticello conventions"
+	self deny: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+	self _validateExpectedMonticelloConventionFailure_389_A: audit packageNames: packageNames className: className
 ]
 
 { #category : 'tests' }
@@ -247,11 +293,13 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_B [
 
 	"https://github.com/GemTalk/Rowan/issues/389"
 
-	"adopt methods without changing protocol to use hybrid convention"
+	"adopt methods into an unpackaged class; 
+		don't use use Monticello convention.
+	 methods should be extension methods."
 
 	| projectName packageNames className packageName theClass symDict symDictName instanceMethod classMethod symbolList audit |
 	projectName := 'AdoptProject'.
-	packageName := 'Adopt-Core'.
+	packageName := 'Adopt-Extensions'.
 	packageNames := {packageName}.
 	symDictName := self _symbolDictionaryName2.
 	className := 'AdoptedClass'.
@@ -305,8 +353,165 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_B [
 	self assert: instanceMethod rowanProjectName = projectName.
 	self assert: classMethod rowanProjectName = projectName.
 
-"audit --> category not correct"
+"audit --> category not correct according to Monticello conventions"
 	self deny: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+	self _validateExpectedMonticelloConventionFailure_389_B: audit packageName: packageName className: className.
+]
+
+{ #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_C [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"adopt methods into a different package than the packaged class; 
+		use use Monticello convention (_A).
+	 methods should be extension methods."
+
+	"adopt methods into a packaged class change protocol to use Monticello convention (_A)"
+
+	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod symbolList audit |
+	projectName := 'AdoptProject'.
+	packageName1 := 'Adopt-Core'.
+	packageName2 := 'Adopt-Extension'.
+	packageNames := {packageName1. packageName2 }.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+	symbolList := Rowan image symbolList.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use non-Rowan api to create class and methods"
+	theClass := Object subclass: className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: symDict
+		options: #().
+	theClass category: packageName1.
+
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptClassNamed: className  
+			intoPackageNamed: packageName1.
+
+	instanceMethod := theClass
+		compileMethod: 'foo ^''foo'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+	classMethod := theClass class
+		compileMethod: 'bar ^''bar'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+	self assert: instanceMethod rowanProjectName = Rowan unpackagedName.
+	self assert: classMethod rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptMethod: #foo 
+			protocol: '*', packageName2 asLowercase
+			inClassNamed: className  
+			isMeta: false 
+			intoPackageNamed: packageName2;
+		adoptMethod: #bar 
+			protocol: '*', packageName2 asLowercase
+			inClassNamed: className  
+			isMeta: true 
+			intoPackageNamed: packageName2;
+		yourself.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName2.
+	self assert: classMethod rowanPackageName = packageName2.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+]
+
+{ #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_D [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"adopt methods into an unpackaged class; 
+		don't use use Monticello convention (_B).
+	 methods should be extension methods."
+
+	"adopt methods change protocol to use Monticello convention (_B)"
+
+	| projectName packageNames className packageName theClass symDict symDictName instanceMethod classMethod symbolList audit |
+	projectName := 'AdoptProject'.
+	packageName := 'Adopt-Extension'.
+	packageNames := {packageName}.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+	symbolList := Rowan image symbolList.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use non-Rowan api to create class and methods"
+	theClass := Object subclass: className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		inDictionary: symDict
+		options: #().
+
+	instanceMethod := theClass
+		compileMethod: 'foo ^''foo'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+	classMethod := theClass class
+		compileMethod: 'bar ^''bar'''
+		dictionaries: symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+	self assert: instanceMethod rowanProjectName = Rowan unpackagedName.
+	self assert: classMethod rowanProjectName = Rowan unpackagedName.
+
+	Rowan packageTools adopt 
+		adoptMethod: #foo 
+			protocol: 'accessing'
+			inClassNamed: className  
+			isMeta: false 
+			intoPackageNamed: packageName;
+		adoptMethod: #bar 
+			protocol: 'accessing'
+			inClassNamed: className  
+			isMeta: true 
+			intoPackageNamed: packageName;
+		yourself.
+
+"validate"
+	self assert: theClass rowanProjectName = Rowan unpackagedName.
+	self assert: instanceMethod rowanProjectName = projectName.
+	self assert: classMethod rowanProjectName = projectName.
+
+"audit --> category not correct according to Monticello conventions"
+	self deny: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+	self _validateExpectedMonticelloConventionFailure_389_B: audit packageName: packageName className: className
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -219,11 +219,10 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_1 [
 
 	"reproduce original bug using adoptMethod:protocol:inClassNamed:isMeta:intoPackageNamed:"
 
-	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod audit |
+	| projectName packageNames className packageName1 theClass symDict symDictName instanceMethod classMethod audit |
 	projectName := 'AdoptProject'.
 	packageName1 := 'Adopt-Core'.
-	packageName2 := 'Adopt-Extension'.
-	packageNames := {packageName1. packageName2 }.
+	packageNames := {packageName1 }.
 	symDictName := self _symbolDictionaryName2.
 	className := 'AdoptedClass'.
 
@@ -295,11 +294,10 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_2 [
 
 	"reproduce original bug using adoptMethod:inClassNamed:isMeta:intoPackageNamed:"
 
-	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod audit |
+	| projectName packageNames className packageName1 theClass symDict symDictName instanceMethod classMethod audit |
 	projectName := 'AdoptProject'.
 	packageName1 := 'Adopt-Core'.
-	packageName2 := 'Adopt-Extension'.
-	packageNames := {packageName1. packageName2 }.
+	packageNames := {packageName1 }.
 	symDictName := self _symbolDictionaryName2.
 	className := 'AdoptedClass'.
 
@@ -361,6 +359,87 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_2 [
 
 "audit --> category not correct according to Monticello conventions"
 	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty. " with bug: 'AdoptedClass #*adopt-core'->'Missing instance method extension category '"
+]
+
+{ #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_3 [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"use adoptMethod:protocol:inClassNamed:isMeta:intoPackageNamed: where protocol is using Monticello convention"
+
+	| projectName packageNames className packageName1 theClass symDict symDictName instanceMethod classMethod audit expectedFailure |
+	projectName := 'AdoptProject'.
+	packageName1 := 'Adopt-Core'.
+	packageNames := {packageName1 }.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use Rowan api to create class and method"
+	theClass := Object
+		rwSubclass:className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+
+	instanceMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: 'accessing'.
+	classMethod := theClass class
+		rwCompileMethod: 'bar ^''bar'''
+		category: 'accessing'.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+
+"change method using non-Rowan api"
+	instanceMethod := theClass
+		compileMethod: 'foo ^"comment" ''foo'''
+		dictionaries: Rowan image symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+"confirm conruption"
+	self assert: instanceMethod rowanPackageName =  Rowan unpackagedName.
+
+"repair corruption using adopt"
+	Rowan packageTools adopt
+		adoptMethod: #foo
+		protocol: '*', packageName1 asLowercase "will cause audit to fail"
+		inClassNamed: className
+		isMeta: false
+		intoPackageNamed:  packageName1.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self deny: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty. "expect: 'AdoptedClass #*adopt-core'->'Extension category name can not be same as class package'"
+
+	self assert: audit size = 1.
+	expectedFailure := ((audit at: packageName1) at: className).
+	self assert: expectedFailure size = 1.
+	self assert: expectedFailure first key =  'AdoptedClass #*adopt-core'.
+	self assert: expectedFailure first value = 'Extension category name can not be same as class package'.
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -213,6 +213,157 @@ RwAdoptToolApiTest >> testAdoptMethod [
 ]
 
 { #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_1 [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"reproduce original bug using adoptMethod:protocol:inClassNamed:isMeta:intoPackageNamed:"
+
+	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod audit |
+	projectName := 'AdoptProject'.
+	packageName1 := 'Adopt-Core'.
+	packageName2 := 'Adopt-Extension'.
+	packageNames := {packageName1. packageName2 }.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use Rowan api to create class and method"
+	theClass := Object
+		rwSubclass:className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+
+	instanceMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: 'accessing'.
+	classMethod := theClass class
+		rwCompileMethod: 'bar ^''bar'''
+		category: 'accessing'.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+
+"change method using non-Rowan api"
+	instanceMethod := theClass
+		compileMethod: 'foo ^"comment" ''foo'''
+		dictionaries: Rowan image symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+"confirm conruption"
+	self assert: instanceMethod rowanPackageName =  Rowan unpackagedName.
+
+"repair corruption using adopt"
+	Rowan packageTools adopt
+		adoptMethod: #foo
+		protocol: 'accessing'
+		inClassNamed: className
+		isMeta: false
+		intoPackageNamed:  packageName1.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty. " with bug: 'AdoptedClass #*adopt-core'->'Missing instance method extension category '"
+]
+
+{ #category : 'tests' }
+RwAdoptToolApiTest >> testAdoptMethod_issue389_2 [
+
+	"https://github.com/GemTalk/Rowan/issues/389"
+
+	"reproduce original bug using adoptMethod:inClassNamed:isMeta:intoPackageNamed:"
+
+	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod audit |
+	projectName := 'AdoptProject'.
+	packageName1 := 'Adopt-Core'.
+	packageName2 := 'Adopt-Extension'.
+	packageNames := {packageName1. packageName2 }.
+	symDictName := self _symbolDictionaryName2.
+	className := 'AdoptedClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: symDictName
+		comment: 'project for testing package adopt api'.
+
+	symDict := Rowan globalNamed: symDictName.
+
+	"Use Rowan api to create class and method"
+	theClass := Object
+		rwSubclass:className
+		instVarNames: #()
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName1
+		options: #().
+
+	instanceMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: 'accessing'.
+	classMethod := theClass class
+		rwCompileMethod: 'bar ^''bar'''
+		category: 'accessing'.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+
+"change method using non-Rowan api"
+	instanceMethod := theClass
+		compileMethod: 'foo ^"comment" ''foo'''
+		dictionaries: Rowan image symbolList
+		category: 'accessing'
+		environmentId: 0.
+
+"confirm conruption"
+	self assert: instanceMethod rowanPackageName =  Rowan unpackagedName.
+
+"repair corruption using adopt"
+	Rowan packageTools adopt
+		adoptMethod: #foo
+		inClassNamed: className
+		isMeta: false
+		intoPackageNamed:  packageName1.
+
+"validate"
+	self assert: theClass rowanPackageName = packageName1.
+	self assert: instanceMethod rowanPackageName = packageName1.
+	self assert: classMethod rowanPackageName = packageName1.
+
+"audit --> category not correct according to Monticello conventions"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty. " with bug: 'AdoptedClass #*adopt-core'->'Missing instance method extension category '"
+]
+
+{ #category : 'tests' }
 RwAdoptToolApiTest >> testAdoptMethod_issue389_A [
 
 	"https://github.com/GemTalk/Rowan/issues/389"

--- a/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwAdoptToolApiTest.class.st
@@ -217,7 +217,7 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_A [
 	"https://github.com/GemTalk/Rowan/issues/389"
 
 	"adopt methods into a different package than the packaged class; 
-		don't use use Monticello convention.
+		don't use Monticello convention.
 	 methods should be extension methods."
 
 	| projectName packageNames className packageName1 packageName2 theClass symDict symDictName instanceMethod classMethod symbolList audit |
@@ -294,7 +294,7 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_B [
 	"https://github.com/GemTalk/Rowan/issues/389"
 
 	"adopt methods into an unpackaged class; 
-		don't use use Monticello convention.
+		don't use Monticello convention.
 	 methods should be extension methods."
 
 	| projectName packageNames className packageName theClass symDict symDictName instanceMethod classMethod symbolList audit |
@@ -365,7 +365,7 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_C [
 	"https://github.com/GemTalk/Rowan/issues/389"
 
 	"adopt methods into a different package than the packaged class; 
-		use use Monticello convention (_A).
+		use Monticello convention (_A).
 	 methods should be extension methods."
 
 	"adopt methods into a packaged class change protocol to use Monticello convention (_A)"
@@ -445,7 +445,7 @@ RwAdoptToolApiTest >> testAdoptMethod_issue389_D [
 	"https://github.com/GemTalk/Rowan/issues/389"
 
 	"adopt methods into an unpackaged class; 
-		don't use use Monticello convention (_B).
+		don't use Monticello convention (_B).
 	 methods should be extension methods."
 
 	"adopt methods change protocol to use Monticello convention (_B)"

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -1109,6 +1109,269 @@ RwBrowserToolApiTest >> testIsExtensionMethod [
 ]
 
 { #category : 'tests' }
+RwBrowserToolApiTest >> testIssue471_1 [
+
+  "https://github.com/dalehenrich/Rowan/issues/471"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 oldClass1 oldClass2 oldClass3  |
+
+  projectName := 'Issue471'.
+  packageName1 := 'Issue471-Core'.
+  packageName2 := 'Issue471-Extensions'.
+  className1 := 'Issue471Class1'.
+  className2 := 'Issue471Class2'.
+  className3 := 'Issue471Class3'.
+  className4 := 'Issue471Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #('ivar2')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #('ivar4' 'ivar3')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+   yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: class3 superClass == class2.
+
+"remove class2 and add class4 -- edit projectDefinition structure in place"
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  packageDefinition removeClassNamed: className2.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className4
+      super: className1
+      instvars: #('ivar2')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+"load"
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: oldClass1 == class1.
+
+  class4 := Rowan globalNamed: className4.
+  self assert: class4 instVarNames = #(ivar2).
+  self assert: class4 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: class3 superClass == oldClass2.
+  self assert: oldClass3 == class3.
+]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testIssue471_2 [
+
+  "https://github.com/dalehenrich/Rowan/issues/471"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 oldClass1 oldClass2 oldClass3  |
+
+  projectName := 'Issue471'.
+  packageName1 := 'Issue471-Core'.
+  packageName2 := 'Issue471-Extensions'.
+  className1 := 'Issue471Class1'.
+  className2 := 'Issue471Class2'.
+  className3 := 'Issue471Class3'.
+  className4 := 'Issue471Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #('ivar2')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #('ivar4' 'ivar3')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+   yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: class3 superClass == class2.
+
+"remove class2 and add class4 -- edit projectDefinition structure in place"
+  projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  packageDefinition removeClassNamed: className2.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className4
+      super: className1
+      instvars: #('ivar2')
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: oldClass1 == class1.
+
+  class4 := Rowan globalNamed: className4.
+  self assert: class4 instVarNames = #(ivar2).
+  self assert: class4 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: class3 superClass == oldClass2.
+  self assert: oldClass3 == class3.
+]
+
+{ #category : 'tests' }
 RwBrowserToolApiTest >> testLoadFullMultiProjectDefs [
 
 	"set up projects and packages for hybrid browser implementation"
@@ -3394,7 +3657,7 @@ RwBrowserToolApiTest >> testRenameClass_1 [
 { #category : 'tests' }
 RwBrowserToolApiTest >> testRenameClass_2 [
 
-  "rename a class with a subclass"
+  "rename a class with a subclass - reference to renamed class in methods"
 
   "https://github.com/dalehenrich/Rowan/issues/470"
 
@@ -3468,6 +3731,174 @@ RwBrowserToolApiTest >> testRenameClass_2 [
       type: 'normal')
     addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
     addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^3' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2.
+
+"perform rename"
+  Rowan projectTools browser
+    renameClassNamed: className2 to: className4.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+  self assert: oldClass1 == class1.
+
+  class4 := Rowan globalNamed: className4.
+  self assert: class4 instVarNames = #(ivar2).
+  self assert: (class4 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class4 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class4 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class4 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class4 superClass == class1.
+  self assert: oldClass2 ~~ class4. "renamed class"
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class4.
+  self assert: oldClass3 ~~ class3. "subclass of renamed class"
+]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_3 [
+
+  "rename a class with a subclass - no references to renamed class in methods"
+
+  "https://github.com/dalehenrich/Rowan/issues/470"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 oldClass1 oldClass2 oldClass3 classExtensionDefinition |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^1' protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^2' protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^3' protocol: 'accessing');
     yourself.
   packageDefinition
     addClassDefinition: classDefinition.

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -3388,5 +3388,173 @@ RwBrowserToolApiTest >> testRenameClass_1 [
   self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
   self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
   self assert: class3 superClass == class2.
-  self assert: oldClass3 ~~ class3.
+  self assert: oldClass3 ~~ class3. "renamed class"
+]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_2 [
+
+  "rename a class with a subclass"
+
+  "https://github.com/dalehenrich/Rowan/issues/470"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 oldClass1 oldClass2 oldClass3 classExtensionDefinition |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^3' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2.
+
+"perform rename"
+  Rowan projectTools browser
+    renameClassNamed: className2 to: className4.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+  self assert: oldClass1 == class1.
+
+  class4 := Rowan globalNamed: className4.
+  self assert: class4 instVarNames = #(ivar2).
+  self assert: (class4 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class4 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class4 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class4 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class4 superClass == class1.
+  self assert: oldClass2 ~~ class4. "renamed class"
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class4.
+  self assert: oldClass3 ~~ class3. "subclass of renamed class"
 ]

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -1111,6 +1111,8 @@ RwBrowserToolApiTest >> testIsExtensionMethod [
 { #category : 'tests' }
 RwBrowserToolApiTest >> testIssue471_1 [
 
+	"expected failure until issue #471 is addressed"
+
   "https://github.com/dalehenrich/Rowan/issues/471"
 
   | projectName  packageName1 packageName2 projectDefinition classDefinition packageDefinition className1 className2 className3
@@ -3988,4 +3990,300 @@ RwBrowserToolApiTest >> testRenameClass_3 [
   self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
   self assert: class3 superClass == class4.
   self assert: oldClass3 ~~ class3. "subclass of renamed class"
+]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_4 [
+
+  "rename a class with a subclass - reference to renamed class in methods subclass references old superclass in method"
+
+  "https://github.com/dalehenrich/Rowan/issues/470"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 classExtensionDefinition validateBlock |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^', className1 protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  validateBlock := [:oldClass1 :oldClass2 :oldClass3 |
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 == oldClass1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 == oldClass2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 == oldClass3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2 ].
+
+   validateBlock value: (Rowan globalNamed: className1) value: (Rowan globalNamed: className2) value: (Rowan globalNamed: className3).
+
+"perform rename --- expect to fail with compile error at the moment"
+	self should: [
+		Rowan projectTools browser
+			renameClassNamed: className2 to: className4 ]
+		raise: CompileError.
+
+"validate"
+  validateBlock value: class1 value: class2 value: class3.
+]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_5 [
+
+  "rename a class with a subclass - reference to renamed class in methods subclass references old superclass in extension method"
+
+  "https://github.com/dalehenrich/Rowan/issues/470"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 class4 validateBlock classExtensionDefinition |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^', className2 protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  validateBlock := [:oldClass1 :oldClass2 :oldClass3 |
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 == oldClass1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 == oldClass2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 == oldClass3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2 ].
+
+   validateBlock value: (Rowan globalNamed: className1) value: (Rowan globalNamed: className2) value: (Rowan globalNamed: className3).
+
+"perform rename"
+	self should: [ 
+		Rowan projectTools browser
+			renameClassNamed: className2 to: className4]
+		raise: CompileError.
+
+"validate"
+   validateBlock value: class1 value: class2 value: class3.
 ]

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -3222,3 +3222,171 @@ RwBrowserToolApiTest >> testNewClassVersionB [
 	self assert: sessionMethodsSeen
 
 ]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_1 [
+
+  "rename a class with no subclasses"
+
+  "https://github.com/dalehenrich/Rowan/issues/470"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition packageDefinition className1 className2 className3
+    className4 projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 classExtensionDefinition |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^3' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2.
+
+"perform rename"
+  Rowan projectTools browser
+    renameClassNamed: className3 to: className4.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: class1 instVarNames = #(ivar1).
+  self assert: (class1 compiledMethodAt: #instanceMethod1) rowanPackageName = packageName1.
+  self assert: (class1 class compiledMethodAt: #classMethod1) rowanPackageName = packageName1.
+  self assert: (class1 compiledMethodAt: #extensionInstanceMethod1) rowanPackageName = packageName2.
+  self assert: (class1 class compiledMethodAt: #extensionClassMethod1) rowanPackageName = packageName2.
+  self assert: oldClass1 == class1.
+
+  class2 := Rowan globalNamed: className2.
+  self assert: class2 instVarNames = #(ivar2).
+  self assert: (class2 compiledMethodAt: #instanceMethod2) rowanPackageName = packageName1.
+  self assert: (class2 class compiledMethodAt: #classMethod2) rowanPackageName = packageName1.
+  self assert: (class2 compiledMethodAt: #extensionInstanceMethod2) rowanPackageName = packageName2.
+  self assert: (class2 class compiledMethodAt: #extensionClassMethod2) rowanPackageName = packageName2.
+  self assert: class2 superClass == class1.
+  self assert: oldClass2 == class2.
+
+  class3 := Rowan globalNamed: className4.
+  self assert: class3 instVarNames = #(ivar4 ivar3).
+  self assert: (class3 compiledMethodAt: #instanceMethod3) rowanPackageName = packageName1.
+  self assert: (class3 class compiledMethodAt: #classMethod3) rowanPackageName = packageName1.
+  self assert: (class3 compiledMethodAt: #extensionInstanceMethod3) rowanPackageName = packageName2.
+  self assert: (class3 class compiledMethodAt: #extensionClassMethod3) rowanPackageName = packageName2.
+  self assert: class3 superClass == class2.
+  self assert: oldClass3 ~~ class3.
+]

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -1332,6 +1332,8 @@ RwBrowserToolApiTest >> testIssue471_2 [
 
 "remove class2 and add class4 -- edit projectDefinition structure in place"
   projectDefinition := (Rowan image loadedProjectNamed: projectName) asDefinition.
+  self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectLoadedDefinitionSourceValue).
+
   packageDefinition := projectDefinition packageNamed: packageName1.
 
   packageDefinition removeClassNamed: className2.

--- a/rowan/src/Rowan-Tests/RwDisownToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwDisownToolApiTest.class.st
@@ -518,6 +518,7 @@ RwDisownToolApiTest >> testDisownProject [
 	self assert: (Rowan image loadedProjectNamed: projectName ifAbsent: []) notNil.
 
 	projectDefinitionToAdopt := (Rowan image loadedProjectNamed: projectName) asDefinition.
+	self assert: (projectDefinitionToAdopt projectDefinitionSourceProperty = RwLoadedProject _projectLoadedDefinitionSourceValue).
 
 	projectTools disown
 		disownProjectNamed: projectName.
@@ -548,5 +549,4 @@ RwDisownToolApiTest >> testDisownProject [
 	self assert: barMethod rowanPackageName = packageName2.
 	self assert: (Rowan image loadedPackageNamed: packageName1 ifAbsent: []) notNil.
 	self assert: (Rowan image loadedProjectNamed: projectName ifAbsent: []) notNil.
-
 ]

--- a/rowan/src/Rowan-Tests/RwEditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwEditToolTest.class.st
@@ -1,6 +1,11 @@
 Class {
 	#name : 'RwEditToolTest',
 	#superclass : 'RwToolTest',
+	#instVars : [
+		'globalBlackList',
+		'userBlackList',
+		'sessionBlackList'
+	],
 	#category : 'Rowan-Tests'
 }
 
@@ -198,6 +203,54 @@ RwEditToolTest >> _standardProjectDefinition: projectName packageNames: packageN
 
 ]
 
+{ #category : 'running' }
+RwEditToolTest >> setUp [
+
+	| preferenceSymbol |
+	super setUp.
+
+"get current black list values"
+	preferenceSymbol := Rowan platform _automaticClassInitializationBlackList_symbol.
+	globalBlackList :=	(Rowan platform 
+		globalPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+	userBlackList :=	(Rowan platform 
+		userPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+	sessionBlackList :=	(Rowan platform 
+		sessionPreferenceFor: preferenceSymbol 
+		ifAbsent: []) copy.
+]
+
+{ #category : 'running' }
+RwEditToolTest >> tearDown [
+
+	| preferenceSymbol |
+
+	super tearDown.
+
+"clean up blackList"
+	preferenceSymbol := Rowan platform _automaticClassInitializationBlackList_symbol.
+	globalBlackList
+		ifNil: [ Rowan clearDefaultAutomaticClassInitializationBlackList ]
+		ifNotNil: [
+			Rowan platform 
+				setDefaultPreferenceFor: preferenceSymbol 
+				to: globalBlackList ].
+	userBlackList
+		ifNil: [ Rowan clearUserAutomaticClassInitializationBlackList ]
+		ifNotNil: [
+			Rowan platform 
+				setUserPreferenceFor: preferenceSymbol 
+				to: userBlackList ].
+	sessionBlackList
+		ifNil: [ Rowan clearSessionAutomaticClassInitializationBlackList ]
+		ifNotNil: [
+			Rowan platform 
+				setSessionPreferenceFor: preferenceSymbol 
+				to: sessionBlackList ].
+]
+
 { #category : 'tests - classes' }
 RwEditToolTest >> testAddAndRemoveClass [
 
@@ -251,6 +304,108 @@ RwEditToolTest >> testAddAndRemoveClass [
 	testClass := Rowan globalNamed: className.
 	self assert: testClass isNil
 
+]
+
+{ #category : 'tests - classes' }
+RwEditToolTest >> testAddClass_blackList_A [
+
+	"https://github.com/GemTalk/Rowan/issues/447"
+
+	"test that blackList is used to block class initialization - sessionAutomaticClassInitializationBlackList"
+
+	| projectName projectDefinition projectTools packageNames classDefinition packageName testClass testInstance className |
+	projectName := 'Simple'.
+	packageName := 'Simple-Core'.
+	packageNames := {packageName}.
+	projectTools := Rowan projectTools.
+
+	{projectName}
+		do: [ :name | 
+			(Rowan image loadedProjectNamed: name ifAbsent: [  ])
+				ifNotNil: [ :project | Rowan image _removeLoadedProject: project ] ].
+
+"create project definition"
+	projectDefinition := self
+		_standardProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment:
+			'Testing class initialization blackList'.
+
+	className := 'SimpleEdit'.
+	classDefinition := self _standardClassDefinition: className.
+
+	projectTools edit
+		addClass: classDefinition
+		inPackageNamed: packageName
+		inProject: projectDefinition.
+
+"add project to session blackList"
+	Rowan sessionAutomaticClassInitializationBlackList add: projectName.
+
+"load project - initialization should not be triggered"
+	[ projectTools load loadProjectDefinition: projectDefinition ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | self assert: false description: 'unexpected signal of RwExecuteClassInitializeMethodsAfterLoadNotification'  ].
+
+"validate"
+	testClass := Rowan globalNamed: className.
+	self assert: testClass notNil.
+	self assert: testClass civar1 isNil.
+	self assert: testClass cvar1 isNil.
+	testInstance := testClass new.
+	self assert: testInstance ivar1 isNil.
+]
+
+{ #category : 'tests - classes' }
+RwEditToolTest >> testAddClass_blackList_B [
+
+	"https://github.com/GemTalk/Rowan/issues/447"
+
+	"test that blackList is used to block class initialization - userAutomaticClassInitializationBlackList"
+
+	| projectName projectDefinition projectTools packageNames classDefinition packageName testClass testInstance className |
+	projectName := 'Simple'.
+	packageName := 'Simple-Core'.
+	packageNames := {packageName}.
+	projectTools := Rowan projectTools.
+
+	{projectName}
+		do: [ :name | 
+			(Rowan image loadedProjectNamed: name ifAbsent: [  ])
+				ifNotNil: [ :project | Rowan image _removeLoadedProject: project ] ].
+
+"create project definition"
+	projectDefinition := self
+		_standardProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment:
+			'Testing class initialization blackList'.
+
+	className := 'SimpleEdit'.
+	classDefinition := self _standardClassDefinition: className.
+
+	projectTools edit
+		addClass: classDefinition
+		inPackageNamed: packageName
+		inProject: projectDefinition.
+
+"add project to user blackList"
+	Rowan userAutomaticClassInitializationBlackList add: projectName.
+
+"load project - initialization should not be triggered"
+	[ projectTools load loadProjectDefinition: projectDefinition ]
+		on: RwExecuteClassInitializeMethodsAfterLoadNotification
+		do: [:ex | self assert: false description: 'unexpected signal of RwExecuteClassInitializeMethodsAfterLoadNotification'  ].
+
+"validate"
+	testClass := Rowan globalNamed: className.
+	self assert: testClass notNil.
+	self assert: testClass civar1 isNil.
+	self assert: testClass cvar1 isNil.
+	testInstance := testClass new.
+	self assert: testInstance ivar1 isNil.
 ]
 
 { #category : 'tests - classes' }
@@ -367,6 +522,41 @@ RwEditToolTest >> testAddUpdateAndRemoveClass [
 	testClass := Rowan globalNamed: className.
 	self assert: testClass isNil
 
+]
+
+{ #category : 'test api' }
+RwEditToolTest >> testPreferences [
+
+	| projectName |
+	projectName := '__Test-Preferences__'.
+
+"standard API - user in GemStone"
+	Rowan automaticClassInitializationBlackList add: projectName.
+	self assert: (Rowan automaticClassInitializationBlackList includes: projectName).
+
+	Rowan clearAutomaticClassInitializationBlackList.
+	self deny: (Rowan automaticClassInitializationBlackList includes: projectName).
+
+"globals"
+	Rowan globalAutomaticClassInitializationBlackList add: projectName.
+	self assert: (Rowan globalAutomaticClassInitializationBlackList includes: projectName).
+
+	Rowan clearGlobalAutomaticClassInitializationBlackList.
+	self deny: (Rowan globalAutomaticClassInitializationBlackList includes: projectName).
+
+"users"
+	Rowan userAutomaticClassInitializationBlackList add: projectName.
+	self assert: (Rowan userAutomaticClassInitializationBlackList includes: projectName).
+
+	Rowan clearUserAutomaticClassInitializationBlackList.
+	self deny: (Rowan userAutomaticClassInitializationBlackList includes: projectName).
+
+"session"
+	Rowan  sessionAutomaticClassInitializationBlackList add: projectName.
+	self assert: (Rowan sessionAutomaticClassInitializationBlackList includes: projectName).
+
+	Rowan clearSessionAutomaticClassInitializationBlackList.
+	self deny: (Rowan sessionAutomaticClassInitializationBlackList includes: projectName).
 ]
 
 { #category : 'tests - classes' }

--- a/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
+++ b/rowan/src/Rowan-Tests/RwPlatformInstanceTest.class.st
@@ -1,0 +1,140 @@
+Class {
+	#name : 'RwPlatformInstanceTest',
+	#superclass : 'RwToolTest',
+	#category : 'Rowan-Tests'
+}
+
+{ #category : 'private' }
+RwPlatformInstanceTest >> _testPreference [
+
+	^#'unknown_preference'
+]
+
+{ #category : 'running' }
+RwPlatformInstanceTest >> tearDown [
+
+	super tearDown.
+	Rowan platform clearAllPreferencesFor: self _testPreference
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testDefaultPrecedence [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance setDefaultPreferenceFor: preference to: #default.
+	self assert: (x := platformInstance preferenceFor: preference) == #default.
+
+	platformInstance setPreferenceFor: preference to: #user.
+	self assert: (x := platformInstance preferenceFor: preference) == #user. 
+
+	self assert: (x := platformInstance defaultPreferenceFor: preference) == #default. 
+
+"testing GemStone implementation"
+	self assert: (x := platformInstance  globalPreferenceFor: preference ifAbsent: [#absent ]) == #default. 
+	self assert: (x := platformInstance  userPreferenceFor: preference ifAbsent: [#absent ]) == #user. 
+	self assert: (x := platformInstance  sessionPreferenceFor: preference ifAbsent: [ #absent ]) == #absent. 
+
+	platformInstance clearPreferenceFor: preference.
+	platformInstance clearDefaultPreferenceFor: preference.
+	self should: [ platformInstance preferenceFor: preference ] raise: Error
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testGlobalPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearGlobalPreferenceFor: preference.
+	self should: [ x := platformInstance globalPreferenceFor: preference ] raise: Error.
+
+	platformInstance setGlobalPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testPreferencePrecedence [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance setGlobalPreferenceFor: preference to: #global.
+	self assert: (platformInstance preferenceFor: preference) == #global.
+
+	platformInstance setUserPreferenceFor: preference to: #user.
+	self assert: (platformInstance preferenceFor: preference) == #user.
+
+	platformInstance setSessionPreferenceFor: preference to: #session.
+	self assert: (platformInstance preferenceFor: preference) == #session.
+
+	platformInstance setPreferenceFor: preference to: #default.
+	self assert: (x := platformInstance preferenceFor: preference) == #default. 
+
+	self assert: (x := platformInstance userPreferenceFor: preference ifAbsent: [ #absent ]) == #default. 		"session prefs cleared and user prefs set"
+	self assert: (x := platformInstance sessionPreferenceFor: preference ifAbsent: [ #absent ]) == #absent. 	"session prefs cleared and user prefs set"
+
+	platformInstance setSessionPreferenceFor: preference to: #session.
+	platformInstance clearPreferenceFor: preference.										"session and user prefs cleared"
+	self assert: (x := platformInstance preferenceFor: preference) == #global.
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	self assert: (platformInstance isKindOf: RwPlatform).
+
+	platformInstance clearPreferenceFor: preference.
+	self should: [ x := platformInstance preferenceFor: preference ] raise: Error.
+
+	platformInstance setPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testSessionPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearSessionPreferenceFor: preference.
+	self should: [ x := platformInstance sessionPreferenceFor: preference ] raise: Error.
+
+	platformInstance setSessionPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]
+
+{ #category : 'test preferences (issue #448)' }
+RwPlatformInstanceTest >> testUserPreferences [
+
+	"https://github.com/GemTalk/Rowan/issues/448"
+
+	| platformInstance  x preference |
+	platformInstance := Rowan platform.
+	preference := self _testPreference.
+
+	platformInstance clearUserPreferenceFor: preference.
+	self should: [ x := platformInstance userPreferenceFor: preference ] raise: Error.
+
+	platformInstance setUserPreferenceFor: preference to: true.
+	self assert: (platformInstance preferenceFor: preference).
+]

--- a/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
@@ -301,7 +301,7 @@ x := Rowan projectTools audit auditForProjectNamed:  'AuditProject'.
 
 	self 
 	  assert: x size = 3;
-	  assert: ((y := x at: packageName1) at: className) size = 2;
+	  assert: ((y := x at: packageName1) at: className) size = 1;
 	  assert: ((y := x at: packageName2) at: className) size = 3;
 	  assert: ((y := x at: packageName3) at: className) size = 2
 
@@ -516,5 +516,47 @@ RwProjectAuditToolTest >> testMissingMethods [
 
 	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 1.
 	self assert: ((x at: packageName) at: className) size = 3
+
+]
+
+{ #category : 'tests' }
+RwProjectAuditToolTest >> testNotification [
+
+| packageTools projectName packageNames className packageName theClass fooMethod |
+	packageTools := Rowan packageTools.
+	projectName := 'AuditProject'.
+	packageName := 'Audit-Core'.
+	packageNames := {packageName}.
+	className := 'AuditClass'.
+
+	self
+		_loadProjectDefinition: projectName
+		packageNames: packageNames
+		defaultSymbolDictName: self _symbolDictionaryName1
+		comment: 'project for testing audit api'.
+
+	theClass := Object
+		rwSubclass: className
+		instVarNames: #(bar)
+		classVars: #()
+		classInstVars: #()
+		poolDictionaries: #()
+		category: packageName
+		options: #().
+	self assert: theClass rowanPackageName = packageName.
+
+	fooMethod := theClass
+		rwCompileMethod: 'foo ^''foo'''
+		category: "'*' , "packageName asLowercase.
+	 
+	fooMethod := theClass class
+		compileMethod: 'new ^super new'
+		dictionaries: #()
+		category: 'Instance Creation'.
+
+	theClass compileMissingAccessingMethods. "this should add: #bar #bar:"
+
+
+	[Rowan projectTools audit auditForProjectNamed:  'AuditProject'] on: Notification do: [:ex | self assert: (ex description matchPattern: {$* . 'Missing loaded instance method' . $*})].
 
 ]

--- a/rowan/src/Rowan-Tests/RwProjectTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectTest.class.st
@@ -4,28 +4,6 @@ Class {
 	#category : 'Rowan-Tests'
 }
 
-{ #category : 'private' }
-RwProjectTest >> gsInteractionConfirmationHandler [
-
-	^ GsInteractionHandler new
-		defaultBlock: [ :ignored | self assert: false description: 'expected a confirmation' ];
-		confirmBlock: [ :interaction | interaction ok ];
-		yourself
-]
-
-{ #category : 'private' }
-RwProjectTest >> handleConfirmationDuring: aBlock [
-
-	"expect a confirmation"
-
-	aBlock
-		on: GsInteractionRequest
-		do: [ :ex | 
-			ex
-				response:
-					(ex interaction interactWith: self gsInteractionConfirmationHandler) ]
-]
-
 { #category : 'tests - issue 428' }
 RwProjectTest >> test_issue428_loaded_no_disk [
 

--- a/rowan/src/Rowan-Tests/RwProjectTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectTest.class.st
@@ -4,6 +4,84 @@ Class {
 	#category : 'Rowan-Tests'
 }
 
+{ #category : 'private' }
+RwProjectTest >> gsInteractionConfirmationHandler [
+
+	^ GsInteractionHandler new
+		defaultBlock: [ :ignored | self assert: false description: 'expected a confirmation' ];
+		confirmBlock: [ :interaction | interaction ok ];
+		yourself
+]
+
+{ #category : 'private' }
+RwProjectTest >> handleConfirmationDuring: aBlock [
+
+	"expect a confirmation"
+
+	aBlock
+		on: GsInteractionRequest
+		do: [ :ex | 
+			ex
+				response:
+					(ex interaction interactWith: self gsInteractionConfirmationHandler) ]
+]
+
+{ #category : 'tests - issue 428' }
+RwProjectTest >> test_issue428_loaded_no_disk [
+
+| projectName  packageName projectDefinition projectSetDefinition audit testClass |
+
+	projectName := 'Issue428'.
+	packageName := 'Issue428-Extension'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"test existsOnDisk"
+
+	self deny: (RwProject newNamed: projectName) existsOnDisk.
+]
+
+{ #category : 'tests - issue 428' }
+RwProjectTest >> test_issue428_loaded_on_disk [
+
+	| projectName projectDefinition projectTools classDefinition packageDefinition packageNames loadedProject |
+	projectName := 'Issue428'.
+	packageNames := #('Issue428-Core' 'Issue428-Tests').
+	projectTools := Rowan projectTools.
+
+	{projectName}
+		do: [ :name | 
+			(Rowan image loadedProjectNamed: name ifAbsent: [  ])
+				ifNotNil: [ :project | Rowan image _removeLoadedProject: project ] ].
+
+	self
+		handleConfirmationDuring: [ 
+			projectDefinition := projectTools create
+				createGitBasedProject: projectName
+				packageNames: packageNames
+				format: 'tonel'
+				root: '/tmp/rowanSimpleProject/' ].
+
+"test existsOnDisk"
+
+	self assert: (RwProject newNamed: projectName) existsOnDisk.
+]
+
 { #category : 'tests' }
 RwProjectTest >> testProjectCreation [
 

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -8606,6 +8606,391 @@ RwRowanProjectIssuesTest >> testIssue41_moveUnchangedInitializeExtensionMethodTo
 
 ]
 
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_1 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_2 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_3 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
 { #category : 'tests-issue 72' }
 RwRowanProjectIssuesTest >> testIssue72_addMethod [
 	"https://github.com/dalehenrich/Rowan/issues/72"

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -8991,6 +8991,606 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_3 [
 	self assert: class3 superclass == class1.
 ]
 
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_4 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_1'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_2'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_3'
+			super: className2, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_1'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_2'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_3'
+			super:  className3, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_5 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	packageName3 := 'Issue467-Core3'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		addPackageNamed: packageName3;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName3;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_1'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_2'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_3'
+			super: className2, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_1'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_2'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_3'
+			super:  className3, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName3
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
+{ #category : 'tests-issue 467' }
+RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_6 [
+
+	"https://github.com/dalehenrich/Rowan/issues/467"
+
+	"
+	1. move shared/common inst var to superclass. [pass]
+	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
+	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
+	"
+
+	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 |
+
+	projectName := 'Issue467'.
+	packageName1 := 'Issue467-Core1'.
+	packageName2 := 'Issue467-Core2'.
+	packageName3 := 'Issue467-Core3'.
+	className1 := 'Issue461Class1'.
+	className2 := 'Issue467Class2'.
+	className3 := 'Issue467Class3'.
+
+	{projectName}
+		do: [ :pn | 
+			(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+				ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+	projectDefinition := (RwProjectDefinition
+		newForGitBasedProjectNamed: projectName)
+		addPackageNamed: packageName1;
+		addPackageNamed: packageName2;
+		addPackageNamed: packageName3;
+		defaultSymbolDictName: self _symbolDictionaryName1;
+		setSymbolDictName: self _symbolDictionaryName2 forPackageNamed: packageName2;
+		setSymbolDictName: self _symbolDictionaryName forPackageNamed: packageName3;
+		yourself.
+
+	packageDefinition := projectDefinition packageNamed: packageName1.
+
+	classDefinition1 := (RwClassDefinition
+		newForClassNamed: className1
+			super: 'Object'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition1.
+
+	classDefinition2 := (RwClassDefinition
+		newForClassNamed: className2
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition2.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_1'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_2'
+			super: className2
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className2, '_extra_3'
+			super: className2, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName1
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName2.
+
+	classDefinition3 := (RwClassDefinition
+		newForClassNamed: className3
+			super: className1
+			instvars: #(ivar1)
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: classDefinition3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_1'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_2'
+			super: className3
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName2
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+	packageDefinition := projectDefinition packageNamed: packageName3.
+
+	extraClassDefinition := (RwClassDefinition
+		newForClassNamed: className3, '_extra_3'
+			super:  className3, '_extra_2'
+			instvars: #()
+			classinstvars: #()
+			classvars: #()
+			category: packageName3
+			comment: 'comment'
+			pools: #()
+			type: 'normal').
+	packageDefinition 
+		addClassDefinition: extraClassDefinition.
+
+"load"
+	projectSetDefinition := RwProjectSetDefinition new.
+	projectSetDefinition addDefinition: projectDefinition.
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	self assert: class2 instVarNames = #(ivar1).
+	self assert: class2 superclass == class1.
+	class3 := Rowan globalNamed: className3.
+	self assert: class3 instVarNames = #(ivar1).
+	self assert: class3 superclass == class1.
+
+"modify class -- new version"
+	classDefinition1 instVarNames: #(ivar1).
+	classDefinition2 instVarNames: #().
+	classDefinition3 instVarNames: #().
+
+"load"
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+"validate"
+	oldClass1 := class1.
+	oldClass2 := class2.
+	oldClass3 := class3.
+	class1 := Rowan globalNamed: className1.
+	class2 := Rowan globalNamed: className2.
+	class3 := Rowan globalNamed: className3.
+
+	self assert: class1 ~~ oldClass1.
+	self assert: class1 instVarNames = #(ivar1).
+
+	self assert: class2 ~~ oldClass2.
+	self assert: class2 instVarNames = #().
+	self assert: class2 superclass == class1.
+
+	self assert: class3 ~~ oldClass3.
+	self assert: class3 instVarNames = #().
+	self assert: class3 superclass == class1.
+]
+
 { #category : 'tests-issue 72' }
 RwRowanProjectIssuesTest >> testIssue72_addMethod [
 	"https://github.com/dalehenrich/Rowan/issues/72"

--- a/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanProjectIssuesTest.class.st
@@ -8615,10 +8615,13 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_1 [
 	1. move shared/common inst var to superclass. [pass]
 	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
 	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -8723,6 +8726,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_1 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 467' }
@@ -8734,10 +8740,13 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_2 [
 	1. move shared/common inst var to superclass. [pass]
 	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
 	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -8843,6 +8852,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_2 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 467' }
@@ -8854,10 +8866,13 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_3 [
 	1. move shared/common inst var to superclass. [pass]
 	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
 	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
+	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -8989,6 +9004,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_3 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 467' }
@@ -9001,10 +9019,12 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_4 [
 	2. move shared/common inst var to superclass. One subclass in different symbol dictionary. [pass]
 	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
 	4. senario 3 with a few more extra subclasses (passing)
+	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -9184,6 +9204,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_4 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 467' }
@@ -9197,10 +9220,11 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_5 [
 	3. scenario 2 with extra subclasses in hierarchy [reproduce bug]
 	4. senario 3 with a few more extra subclasses (passing)
 	5. senario 4 moving a subclass to another package (in same symbol dictionary)
+	6. senario 4 moving a subclass to another package (in different symbol dictionary)
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -9386,6 +9410,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_5 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 467' }
@@ -9403,7 +9430,7 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_6 [
 	"
 
 	| projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition2 classDefinition3 packageDefinition className1 className2 className3 
-		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 |
+		projectSetDefinition class1 class2 class3 oldClass1 oldClass2 oldClass3 extraClassDefinition packageName3 audit |
 
 	projectName := 'Issue467'.
 	packageName1 := 'Issue467-Core1'.
@@ -9589,6 +9616,9 @@ RwRowanProjectIssuesTest >> testIssue467_new_version_class_with_subclasses_6 [
 	self assert: class3 ~~ oldClass3.
 	self assert: class3 instVarNames = #().
 	self assert: class3 superclass == class1.
+
+"audit"
+	self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
 ]
 
 { #category : 'tests-issue 72' }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -48,6 +48,41 @@ RwRowanSample4Test >> _rowanSample4SpecificationUrl [
 ]
 
 { #category : 'tests' }
+RwRowanSample4Test >> test_projectUrl_issue_463 [
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath |
+	projectName := 'RowanSample4'.
+	(Rowan image loadedProjectNamed: projectName ifAbsent: [  ])
+		ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	project := RwProject newNamed: projectName.
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+
+	self assert: project projectUrl = rowanSampleSpec projectUrl.
+	self assert: project projectUrl = 'https://github.com/dalehenrich/RowanSample4'.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self assert: project projectUrl = 'https://github.com/dalehenrich/RowanSample4'.
+]
+
+{ #category : 'tests' }
 RwRowanSample4Test >> testCreateProjectDefinition [
 
 	| specUrlString projectTools rowanSpec gitRootPath projectName projectDefinition x |

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -2074,7 +2074,7 @@ RwRowanSample4Test >> testIssue305 [
 ]
 
 { #category : 'tests' }
-RwRowanSample4Test >> testIssue460 [
+RwRowanSample4Test >> testIssue460_1 [
 
 	"https://github.com/dalehenrich/Rowan/issues/260"
 
@@ -2180,6 +2180,116 @@ projectSetDefinition addProject: oldProjectDefinition.
 ]
 
 { #category : 'tests' }
+RwRowanSample4Test >> testIssue460_2 [
+
+	"https://github.com/dalehenrich/Rowan/issues/260"
+
+	"Error creating a new class version of a superclass while moving to a new package in a new project and a new symbol dictionary"
+
+	"issue_295_6 --> issue_295_7	:: rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+													move new version of NewRowanSample4  with subclass (and method) to RowanSample4SymbolDict in new project"
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath 
+		baselinePackageNames newClass ar oldClass projectDefinition projectSetDefinition oldProjectDefinition subclass |
+
+	projectName := 'RowanSample4'.
+	{ projectName . projectName, '_295'} do: [:pn |
+		(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+			ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ] ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	repoRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_0'.				"starting point of test"
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	project := RwProject newNamed: projectName.
+	baselinePackageNames := #( 'RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-Tests' 'RowanSample4-GemStone' 
+											'RowanSample4-GemStone-Tests').
+	self
+		assert:
+			(x := project packageNames asArray sort) =  baselinePackageNames sort.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	self assert: (x := rowanSampleSpec loadedGroupNames) = #('tests').
+	self assert: (x := rowanSampleSpec loadedConfigurationNames) = #('Load').
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_6'.				"New package added to the project, along with a subclass of NewRowanSample4 with method"
+
+	self assert: (Rowan globalNamed: 'NewRowanSample4') isNil.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self
+		assert:
+			(x := project packageNames asArray sort) =  (baselinePackageNames, #('RowanSample4-NewPackage')) sort.
+
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (ar first at: 1) name = #'RowanSample4DictionarySymbolDict'.
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_7'.				"Rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+																								move new version of NewRowanSampleSubclass4 to RowanSample4SymbolDict"
+"trigger the bug on this load"
+	specUrlString := self _rowanSample4LoadSpecificationUrl_295.
+
+"need to add old project definition with all classes and extensions removed to the projectSet Definition to reproduce bug"
+	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
+	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
+
+oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
+projectSetDefinition addProject: oldProjectDefinition.
+
+	oldProjectDefinition packages values do: [:pkgDefinition |
+	    pkgDefinition classDefinitions values do: [:classDefinition |
+	        pkgDefinition removeClassDefinition: classDefinition ].
+	    pkgDefinition classExtensions values do: [:classExtension |
+        	pkgDefinition removeClassExtension: classExtension ]].
+
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+	Rowan projectTools load markProjectSetNotDirty: projectSetDefinition.
+
+
+	oldClass := newClass.
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: oldClass ~~ newClass.
+	self assert: newClass new foo = 'foo'.
+
+	subclass := Rowan globalNamed: 'NewRowanSampleSubclass4'.
+	self assert: subclass new foo = 'foo'.
+	self assert: subclass foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (x := (ar first at: 1) name) = #'RowanSample4DictionarySymbolDict_295_3'.
+
+	self deny: ((Rowan globalNamed: 'RowanSample4DictionarySymbolDict') includesKey: #'NewRowanSample4')
+]
+
+{ #category : 'tests' }
 RwRowanSample4Test >> testLoadProjectFromUrl_1 [
 
 	| specUrlString projectTools rowanSpec gitRootPath projectName projectDefinition spec theClass |
@@ -2248,7 +2358,6 @@ RwRowanSample4Test >> testLoadProjectFromUrl_2 [
 	theClass := Rowan globalNamed: 'RowanSample4'.
 
 	self assert: theClass new foo = 'foo'
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -1617,6 +1617,7 @@ RwRowanSample4Test >> testIssue230 [
 	"Create and load the primer project ... with two packages into which the classes will be adopted"
 	projectDefinition := RwProjectDefinition
 		newForGitBasedProjectNamed: primerProjectName.
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectUnknownDefinitionSourceValue).
 	projectDefinition
 		addPackageNamed: primerPackageName1;
 		addPackageNamed: primerPackageName2;
@@ -1650,7 +1651,6 @@ RwRowanSample4Test >> testIssue230 [
 	projectTools load
 		loadProjectNamed: projectName
 		instanceMigrator: RwGsInstanceMigrator noMigration.
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -1754,7 +1754,6 @@ RwRowanSample4Test >> testIssue305 [
 		loadProjectFromSpecUrl: 'file:' , repoRootPath, '/rowan/specs/RowanSample4_core.ston'.
 
 	self assert: (Rowan globalNamed: 'RowanSample4Test') isNil.
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -112,10 +112,11 @@ RwRowanSample4Test >> testCreateProjectDefinition [
 	
 	projectTools read readProjectDefinition: projectDefinition.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
+
 	self assert: (x := projectDefinition packageNames asArray sort) = #('RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-GemStone' 'RowanSample4-GemStone-Tests' 'RowanSample4-Tests') sort.
 
 	self assert: (Rowan image loadedProjectNamed: projectName ifAbsent: []) isNil.
-
 ]
 
 { #category : 'tests' }
@@ -1876,6 +1877,8 @@ RwRowanSample4Test >> testIssue295_rename_package_move_newClassVersion_newProjec
 	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
 	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
+
 oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
 projectSetDefinition addProject: oldProjectDefinition.
 
@@ -1983,6 +1986,8 @@ RwRowanSample4Test >> testIssue295_rename_package_move_newClassVersion_with_subc
 "need to add old project definition with all classes and extensions removed to the projectSet Definition to reproduce bug"
 	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
 	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
+
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
 
 oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
 projectSetDefinition addProject: oldProjectDefinition.
@@ -2189,6 +2194,8 @@ RwRowanSample4Test >> testIssue460_1 [
 	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
 	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
+
 oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
 projectSetDefinition addProject: oldProjectDefinition.
 
@@ -2295,6 +2302,8 @@ RwRowanSample4Test >> testIssue460_2 [
 	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
 	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
+
 oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
 projectSetDefinition addProject: oldProjectDefinition.
 
@@ -2353,6 +2362,8 @@ RwRowanSample4Test >> testLoadProjectFromUrl_1 [
 
 	projectTools read readProjectDefinition: projectDefinition.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue).
+
 	self assert: (Rowan image loadedProjectNamed: projectName ifAbsent: []) notNil.
 
 	projectTools load loadProjectNamed: projectName.
@@ -2360,7 +2371,6 @@ RwRowanSample4Test >> testLoadProjectFromUrl_1 [
 	theClass := Rowan globalNamed: 'RowanSample4'.
 
 	self assert: theClass new foo = 'foo'
-
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
+++ b/rowan/src/Rowan-Tests/RwRowanSample4Test.class.st
@@ -7,8 +7,9 @@ Class {
 { #category : 'private' }
 RwRowanSample4Test class >> _symbolDictionaryNames [
 
-	^ 	super _symbolDictionaryNames, #(#'RowanSample4SymbolDict' #'RowanSample4DictionarySymbolDict')
-
+	^ 	super _symbolDictionaryNames, 
+			#( #'RowanSample4SymbolDict' #'RowanSample4DictionarySymbolDict' #'RowanSample4DictionarySymbolDict_295'
+					#'RowanSample4DictionarySymbolDict_295_3')
 ]
 
 { #category : 'private' }
@@ -27,6 +28,14 @@ RwRowanSample4Test >> _rowanSample4LoadSpecificationUrl [
 	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
 	^ 'file:' , rowanSpec repositoryRootPath , '/test/specs/RowanSample4_load.ston'
 
+]
+
+{ #category : 'private' }
+RwRowanSample4Test >> _rowanSample4LoadSpecificationUrl_295 [
+
+	| rowanSpec |
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	^ 'file:' , rowanSpec repositoryRootPath , '/test/specs/RowanSample4_295.ston'
 ]
 
 { #category : 'private' }
@@ -1658,6 +1667,314 @@ RwRowanSample4Test >> testIssue284 [
 ]
 
 { #category : 'tests' }
+RwRowanSample4Test >> testIssue295_rename_package_move_newClassVersion_newProject_1 [
+
+	"https://github.com/dalehenrich/Rowan/issues/295"
+
+	"Error creating a new class version while moving to a new package in a new project and a new symbol dictionary"
+
+	"issue_295_1 --> issue_295_2	:: rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+													move new version of NewRowanSample4 to RowanSample4SymbolDict in new project"
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath 
+		baselinePackageNames newClass ar oldClass |
+
+	projectName := 'RowanSample4'.
+	{ projectName . projectName, '_295'} do: [:pn |
+		(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+			ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ] ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	repoRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_0'.				"starting point of test"
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	project := RwProject newNamed: projectName.
+	baselinePackageNames := #( 'RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-Tests' 'RowanSample4-GemStone' 
+											'RowanSample4-GemStone-Tests').
+	self
+		assert:
+			(x := project packageNames asArray sort) =  baselinePackageNames sort.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	self assert: (x := rowanSampleSpec loadedGroupNames) = #('tests').
+	self assert: (x := rowanSampleSpec loadedConfigurationNames) = #('Load').
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_1'.				"New package added to the project"
+
+	self assert: (Rowan globalNamed: 'NewRowanSample4') isNil.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self
+		assert:
+			(x := project packageNames asArray sort) =  (baselinePackageNames, #('RowanSample4-NewPackage')) sort.
+
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (ar first at: 1) name = #'RowanSample4DictionarySymbolDict'.
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_2'.				"Rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+																								move new version of NewRowanSample4 to RowanSample4SymbolDict"
+"trigger the bug on this load"
+	specUrlString := self _rowanSample4LoadSpecificationUrl_295.
+	projectTools load
+		loadProjectFromSpecUrl: specUrlString
+		projectRootPath: repoRootPath.
+
+	oldClass := newClass.
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: oldClass ~~ newClass.
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (x := (ar first at: 1) name) = #'RowanSample4DictionarySymbolDict_295'.
+
+	self deny: ((Rowan globalNamed: 'RowanSample4DictionarySymbolDict') includesKey: #'NewRowanSample4')
+]
+
+{ #category : 'tests' }
+RwRowanSample4Test >> testIssue295_rename_package_move_newClassVersion_newProject_2 [
+
+	"attempting to reproduce the actual issue (_1 doesn't reproduce problem, but should remain static to ensure behavior does not change detrimentally"
+
+	"https://github.com/dalehenrich/Rowan/issues/295"
+
+	"Error creating a new class version while moving to a new package in a new project and a new symbol dictionary"
+
+	"issue_295_1 --> issue_295_3	:: rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+													move new version of NewRowanSample4 to RowanSample4SymbolDict in new project"
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath 
+		baselinePackageNames newClass ar oldClass projectDefinition projectSetDefinition oldProjectDefinition |
+
+	projectName := 'RowanSample4'.
+	{ projectName . projectName, '_295'} do: [:pn |
+		(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+			ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ] ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	repoRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_0'.				"starting point of test"
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	project := RwProject newNamed: projectName.
+	baselinePackageNames := #( 'RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-Tests' 'RowanSample4-GemStone' 
+											'RowanSample4-GemStone-Tests').
+	self
+		assert:
+			(x := project packageNames asArray sort) =  baselinePackageNames sort.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	self assert: (x := rowanSampleSpec loadedGroupNames) = #('tests').
+	self assert: (x := rowanSampleSpec loadedConfigurationNames) = #('Load').
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_1'.				"New package added to the project"
+
+	self assert: (Rowan globalNamed: 'NewRowanSample4') isNil.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self
+		assert:
+			(x := project packageNames asArray sort) =  (baselinePackageNames, #('RowanSample4-NewPackage')) sort.
+
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (ar first at: 1) name = #'RowanSample4DictionarySymbolDict'.
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_3'.				"Rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+																								move new version of NewRowanSample4 to RowanSample4SymbolDict"
+"trigger the bug on this load"
+	specUrlString := self _rowanSample4LoadSpecificationUrl_295.
+
+"need to add old project definition with all classes and extensions removed to the projectSet Definition to reproduce bug"
+	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
+	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
+
+oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
+projectSetDefinition addProject: oldProjectDefinition.
+
+	oldProjectDefinition packages values do: [:pkgDefinition |
+	    pkgDefinition classDefinitions values do: [:classDefinition |
+	        pkgDefinition removeClassDefinition: classDefinition ].
+	    pkgDefinition classExtensions values do: [:classExtension |
+        	pkgDefinition removeClassExtension: classExtension ]].
+
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+	Rowan projectTools load markProjectSetNotDirty: projectSetDefinition.
+
+
+	oldClass := newClass.
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: oldClass ~~ newClass.
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (x := (ar first at: 1) name) = #'RowanSample4DictionarySymbolDict_295_3'.
+
+	self deny: ((Rowan globalNamed: 'RowanSample4DictionarySymbolDict') includesKey: #'NewRowanSample4')
+]
+
+{ #category : 'tests' }
+RwRowanSample4Test >> testIssue295_rename_package_move_newClassVersion_with_subclass_newProject [
+
+	"attempting to reproduce the actual issue (_1 doesn't reproduce problem, but should remain static to ensure behavior does not change detrimentally"
+
+	"https://github.com/dalehenrich/Rowan/issues/295"
+
+	"Error creating a new class version of a superclass while moving to a new package in a new project and a new symbol dictionary"
+
+	"issue_295_4 --> issue_295_5	:: rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+													move new version of NewRowanSample4  with subclass to RowanSample4SymbolDict in new project"
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath 
+		baselinePackageNames newClass ar oldClass projectDefinition projectSetDefinition oldProjectDefinition |
+
+	projectName := 'RowanSample4'.
+	{ projectName . projectName, '_295'} do: [:pn |
+		(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+			ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ] ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	repoRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_0'.				"starting point of test"
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	project := RwProject newNamed: projectName.
+	baselinePackageNames := #( 'RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-Tests' 'RowanSample4-GemStone' 
+											'RowanSample4-GemStone-Tests').
+	self
+		assert:
+			(x := project packageNames asArray sort) =  baselinePackageNames sort.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	self assert: (x := rowanSampleSpec loadedGroupNames) = #('tests').
+	self assert: (x := rowanSampleSpec loadedConfigurationNames) = #('Load').
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_4'.				"New package added to the project, along with a subclass of NewRowanSample4"
+
+	self assert: (Rowan globalNamed: 'NewRowanSample4') isNil.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self
+		assert:
+			(x := project packageNames asArray sort) =  (baselinePackageNames, #('RowanSample4-NewPackage')) sort.
+
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (ar first at: 1) name = #'RowanSample4DictionarySymbolDict'.
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_5'.				"Rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+																								move new version of NewRowanSampleSubclass4 to RowanSample4SymbolDict"
+"trigger the bug on this load"
+	specUrlString := self _rowanSample4LoadSpecificationUrl_295.
+
+"need to add old project definition with all classes and extensions removed to the projectSet Definition to reproduce bug"
+	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
+	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
+
+oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
+projectSetDefinition addProject: oldProjectDefinition.
+
+	oldProjectDefinition packages values do: [:pkgDefinition |
+	    pkgDefinition classDefinitions values do: [:classDefinition |
+	        pkgDefinition removeClassDefinition: classDefinition ].
+	    pkgDefinition classExtensions values do: [:classExtension |
+        	pkgDefinition removeClassExtension: classExtension ]].
+
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+	Rowan projectTools load markProjectSetNotDirty: projectSetDefinition.
+
+
+	oldClass := newClass.
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: oldClass ~~ newClass.
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (x := (ar first at: 1) name) = #'RowanSample4DictionarySymbolDict_295_3'.
+
+	self deny: ((Rowan globalNamed: 'RowanSample4DictionarySymbolDict') includesKey: #'NewRowanSample4')
+]
+
+{ #category : 'tests' }
 RwRowanSample4Test >> testIssue304 [
 
 	"https://github.com/dalehenrich/Rowan/issues/304"
@@ -1754,6 +2071,112 @@ RwRowanSample4Test >> testIssue305 [
 		loadProjectFromSpecUrl: 'file:' , repoRootPath, '/rowan/specs/RowanSample4_core.ston'.
 
 	self assert: (Rowan globalNamed: 'RowanSample4Test') isNil.
+]
+
+{ #category : 'tests' }
+RwRowanSample4Test >> testIssue460 [
+
+	"https://github.com/dalehenrich/Rowan/issues/260"
+
+	"Error creating a new class version of a superclass while moving to a new package in a new project and a new symbol dictionary"
+
+	"issue_295_6 --> issue_295_5	:: rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+													move new version of NewRowanSample4  with subclass (and method) to RowanSample4SymbolDict in new project"
+
+	| specUrlString projectTools rowanSpec gitTool gitRootPath projectName rowanSampleSpec project x repoRootPath 
+		baselinePackageNames newClass ar oldClass projectDefinition projectSetDefinition oldProjectDefinition |
+
+	projectName := 'RowanSample4'.
+	{ projectName . projectName, '_295'} do: [:pn |
+		(Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+			ifNotNil: [ :prj | Rowan image _removeLoadedProject: prj ] ].
+
+	rowanSpec := (Rowan image _projectForNonTestProject: 'Rowan') specification.
+	specUrlString := self _rowanSample4LoadSpecificationUrl.
+	projectTools := Rowan projectTools.
+
+	gitRootPath := rowanSpec repositoryRootPath , '/test/testRepositories/repos/'.
+
+	(Rowan fileUtilities directoryExists: gitRootPath , projectName)
+		ifTrue: [ Rowan fileUtilities deleteAll: gitRootPath , projectName ].
+
+	projectTools clone
+		cloneSpecUrl: specUrlString
+		gitRootPath: gitRootPath
+		useSsh: true.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	repoRootPath := rowanSampleSpec repositoryRootPath.
+
+	gitTool := projectTools git.
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_0'.				"starting point of test"
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	project := RwProject newNamed: projectName.
+	baselinePackageNames := #( 'RowanSample4-Core' 'RowanSample4-Extensions' 'RowanSample4-Tests' 'RowanSample4-GemStone' 
+											'RowanSample4-GemStone-Tests').
+	self
+		assert:
+			(x := project packageNames asArray sort) =  baselinePackageNames sort.
+
+	rowanSampleSpec := (Rowan image loadedProjectNamed: projectName) specification.
+	self assert: (x := rowanSampleSpec loadedGroupNames) = #('tests').
+	self assert: (x := rowanSampleSpec loadedConfigurationNames) = #('Load').
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_6'.				"New package added to the project, along with a subclass of NewRowanSample4 with method"
+
+	self assert: (Rowan globalNamed: 'NewRowanSample4') isNil.
+
+	projectTools load
+		loadProjectNamed: projectName
+		instanceMigrator: RwGsInstanceMigrator noMigration.
+
+	self
+		assert:
+			(x := project packageNames asArray sort) =  (baselinePackageNames, #('RowanSample4-NewPackage')) sort.
+
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (ar first at: 1) name = #'RowanSample4DictionarySymbolDict'.
+
+	gitTool gitcheckoutIn: repoRootPath with: 'issue_295_5'.				"Rename RowanSample4-NewPackage to RowanSample4-RenamedPackage; 
+																								move new version of NewRowanSampleSubclass4 to RowanSample4SymbolDict"
+"trigger the bug on this load"
+	specUrlString := self _rowanSample4LoadSpecificationUrl_295.
+
+"need to add old project definition with all classes and extensions removed to the projectSet Definition to reproduce bug"
+	projectDefinition := Rowan projectTools create createProjectDefinitionFromSpecUrl: specUrlString projectRootPath: repoRootPath.
+	projectSetDefinition := Rowan projectTools read readProjectSetForProjectDefinition: projectDefinition.
+
+oldProjectDefinition := (Rowan image loadedProjectNamed: 'RowanSample4') asDefinition.
+projectSetDefinition addProject: oldProjectDefinition.
+
+	oldProjectDefinition packages values do: [:pkgDefinition |
+	    pkgDefinition classDefinitions values do: [:classDefinition |
+	        pkgDefinition removeClassDefinition: classDefinition ].
+	    pkgDefinition classExtensions values do: [:classExtension |
+        	pkgDefinition removeClassExtension: classExtension ]].
+
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+	Rowan projectTools load markProjectSetNotDirty: projectSetDefinition.
+
+
+	oldClass := newClass.
+	newClass := Rowan globalNamed: 'NewRowanSample4'.
+
+	self assert: oldClass ~~ newClass.
+	self assert: newClass new foo = 'foo'.
+
+	ar := Rowan image symbolList dictionariesAndSymbolsOf: newClass.
+	self assert: (x := (ar first at: 1) name) = #'RowanSample4DictionarySymbolDict_295_3'.
+
+	self deny: ((Rowan globalNamed: 'RowanSample4DictionarySymbolDict') includesKey: #'NewRowanSample4')
 ]
 
 { #category : 'tests' }

--- a/rowan/src/Rowan-Tests/RwToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwToolTest.class.st
@@ -5,34 +5,12 @@ Class {
 }
 
 { #category : 'private' }
-RwToolTest >> gsInteractionConfirmationHandler [
-
-	^ GsInteractionHandler new
-		defaultBlock: [ :ignored | self assert: false description: 'expected a confirmation' ];
-		confirmBlock: [ :interaction | interaction ok ];
-		yourself
-]
-
-{ #category : 'private' }
 RwToolTest >> gsInteractionInformFailureHandler [
 
 	^ GsInteractionHandler new
 		defaultBlock: [ :ignored | self assert: false description: 'unexpected interaction' ];
 		informBlock: [ :interaction | self assert: false description: 'unexpected inform' ];
 		yourself
-]
-
-{ #category : 'private' }
-RwToolTest >> handleConfirmationDuring: aBlock [
-
-	"expect a confirmation"
-
-	aBlock
-		on: GsInteractionRequest
-		do: [ :ex | 
-			ex
-				response:
-					(ex interaction interactWith: self gsInteractionConfirmationHandler) ]
 ]
 
 { #category : 'private' }

--- a/rowan/src/Rowan-Tests/RwUnpackagedBrowserApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwUnpackagedBrowserApiTest.class.st
@@ -93,6 +93,8 @@ RwUnpackagedBrowserApiTest >> testIssue263 [
 		defaultSymbolDictName: self _symbolDictionaryName1;
 		yourself.
 
+	self assert: (projectDefinition projectDefinitionSourceProperty = RwLoadedProject _projectUnknownDefinitionSourceValue).
+
 "load"
 	projectSetDefinition := RwProjectSetDefinition new.
 	projectSetDefinition addDefinition: projectDefinition.

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -29,14 +29,15 @@ RwClsAuditTool >> _auditCategory: category forBehavior: aBehavior loadedClass: a
 					ifAbsent: [nil]) isNil 
 						ifTrue: [ | res | 
 									res := self _auditCategory: category selectors: (aBehavior selectorsIn: category)  forBehavior: aBehavior loadedClass: aLoadedClass		.
-									res add: (aLoadedClass name , ' #' , category asString -> 'Class Extension is not present in the package '); 
-									yourself
+									"res add: (aLoadedClass name , ' #' , category asString -> 'Class Extension is not present in the package '); 
+									yourself"
 						] 
 						ifFalse: [{}"no basic extension problems found, class extension will be audited separately"]
 			]
 	] ifFalse: [
 		self _auditCategory: category selectors: (aBehavior selectorsIn: category)  forBehavior: aBehavior loadedClass: aLoadedClass		
 	]
+
 ]
 
 { #category : 'audit' }
@@ -148,7 +149,7 @@ RwClsAuditTool >> _auditSelector: aSelector forBehavior: aBehavior loadedClass: 
 						ifTrue: [
 							((aLoadedMethod propertyAt: 'protocol') equalsNoCase: (aBehavior categoryOfSelector:   aSelector ) ) 
 								ifTrue: [nil]
-								ifFalse: [aLoadedClass name , '#', (aLoadedMethod propertyAt: 'protocol') -> 'Missing class method category for loaded class']
+								ifFalse: [aLoadedClass name , '#', (aLoadedMethod propertyAt: 'protocol') -> 'Missing instance method category for loaded class']
 						] 
 						ifFalse: [(aLoadedClass name ,  ' >> ', aSelector) -> 'Compiled instance method is not identical to loaded method. ']
 			]
@@ -197,7 +198,8 @@ RwClsAuditTool >> auditLoadedClass: aLoadedClass [
 RwClsAuditTool >> errorLog: aResult add: aMessage [	
 "add error to results. print to file"
 	aResult add: aMessage.
-	GsFile gciLogServer: aMessage value asString,'  ', aMessage key asString
+	GsFile gciLogServer: aMessage value asString,'  ', aMessage key asString.
+	Notification signal: aMessage value asString,'  ', aMessage key asString.
 
 ]
 

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -113,12 +113,11 @@ RwClsAuditTool >> _auditLoadedClassProperties: aLoadedClass forBehavior: aBehavi
 	((aLoadedClass propertyAt: 'category') = aBehavior category ) 
 			ifFalse: [self errorLog: res  add: aLoadedClass name -> 'Class category has changed in compiled class v loaded class'].
 	(aDict := System myUserProfile resolveSymbol: (aLoadedClass propertyAt: 'gs_SymbolDictionary') asSymbol ) 
-			ifNil: [self errorLog: res  add: 'Unable to find SymbolDictionary for LoadedClass'] 
+			ifNil: [self errorLog: res  add: aLoadedClass name -> ('Unable to find SymbolDictionary ' ,(aLoadedClass propertyAt: 'gs_SymbolDictionary'))] 
 			ifNotNil: [:smbd | smbd value at: aLoadedClass name asSymbol 
 					ifAbsent: [self errorLog: res  add: aLoadedClass name -> 'Compiled class not found in symbol dictionary of loaded class']] .
 
 	^res
-
 ]
 
 { #category : 'audit' }

--- a/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
@@ -29,7 +29,7 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 	res := self _result.
 	extensionCategoryName :=  aLoadedClassExtension loadedPackage asExtensionName "'*' , aLoadedClassExtension loadedPackage name" .
 	(Rowan globalNamed: aLoadedClassExtension name) 
-		ifNil: [self errorLog: res  add: aLoadedClassExtension name -> ' Class does not exists '] 
+		ifNil: [self errorLog: res  add: aLoadedClassExtension name -> ' Class does not exists for loaded class '] 
 		ifNotNil: [:aBehavior ||categories | 
 					
 				categories := (aBehavior _baseCategorys: 0) keys.
@@ -37,7 +37,7 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 					detect: [:each | each equalsNoCase: extensionCategoryName ] ifNone: [ ])
 						ifNotNil: [:aCategory | self errorLog: res  addAll:  (self _auditCategory: aCategory forBehavior: aBehavior loadedClass: aLoadedClassExtension)]
 						ifNil: [aLoadedClassExtension loadedInstanceMethods notEmpty ifTrue: [
-							self errorLog: res add: aLoadedClassExtension name , ' #' ,extensionCategoryName -> 'Missing extension category ']
+							self errorLog: res add: aLoadedClassExtension name , ' #' ,extensionCategoryName -> 'Missing instance method extension category ']
 			].
 
 
@@ -46,7 +46,7 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 				detect: [:each | each equalsNoCase: extensionCategoryName ] ifNone: [ ])
 					ifNotNil: [:aCategory | self errorLog: res  addAll:  (self _auditCategory: aCategory forBehavior: aBehavior class loadedClass: aLoadedClassExtension)]
 					ifNil: [aLoadedClassExtension loadedClassMethods notEmpty ifTrue: [
-						self errorLog: res add: aLoadedClassExtension name , ' #' ,extensionCategoryName -> 'Missing classmethod extension category ']
+						self errorLog: res add: aLoadedClassExtension name , ' #' ,extensionCategoryName -> 'Missing class method extension category ']
 			].
 
 		
@@ -59,4 +59,5 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 				]
 		].
 		^res
+
 ]

--- a/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwGitTool.class.st
@@ -36,10 +36,9 @@ RwGitTool >> gitBranchNameIn: gitRepoPath [
 	"return current branch for git repository located at gitPath"
 
 	| command result |
-	command := 'set -e; cd ' , gitRepoPath , '; git rev-parse --abbrev-ref HEAD'.
+	command := 'set -e; cd ' , gitRepoPath , ';git branch | sed -n ''/\* /s///p'''.
 	result := self performOnServer: command logging: false.
 	^ result trimWhiteSpace
-
 ]
 
 { #category : 'smalltalk api' }

--- a/rowan/src/Rowan-Tools-Core/RwPkgAdoptTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPkgAdoptTool.class.st
@@ -144,7 +144,7 @@ RwPkgAdoptTool >> adoptMethod: methodSelector protocol: protocolString inClassNa
 		move the method into protocol <protocolString> "
 
 	| loadedPackage loadedProject gemstoneSpec packageSymDictName theClass theSymbolDictionary registry 
-		theBehavior theCompiledMethod |
+		theBehavior theCompiledMethod extensionMethod |
 	loadedPackage := Rowan image loadedPackageNamed: packageName.
 	loadedProject := loadedPackage loadedProject.
 
@@ -165,12 +165,20 @@ RwPkgAdoptTool >> adoptMethod: methodSelector protocol: protocolString inClassNa
 	theCompiledMethod rowanProjectName = Rowan unpackagedName
 		ifFalse: [ self error: 'The method ', className printString, '>>', methodSelector asString, ' is already packaged ... no need to adopt' ].
 
-	registry
-		addExtensionCompiledMethod: theCompiledMethod 
-		for: theBehavior 
-		protocol: protocolString 
-		toPackageNamed: packageName
-
+	theClass  rowanPackageName ~= packageName
+		ifTrue: [ 
+			registry
+				addExtensionCompiledMethod: theCompiledMethod 
+				for: theBehavior 
+				protocol: protocolString 
+				toPackageNamed: packageName ]
+		ifFalse: [ 
+			registry
+				adoptCompiledMethod: theCompiledMethod 
+				classExtension: false
+				for: theBehavior 
+				protocol: protocolString
+				toPackageNamed: packageName ].
 ]
 
 { #category : 'smalltalk api' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjAuditTool.class.st
@@ -6,13 +6,18 @@ Class {
 
 { #category : 'other' }
 RwPrjAuditTool >> auditAll [
+	
+	^self auditAllForUser: System myUserProfile userId
+]
+
+{ #category : 'other' }
+RwPrjAuditTool >> auditAllForUser: aUserId [
 | res |
 	res := StringKeyValueDictionary new.
-			(Rowan image  _loadedProjectRegistryForUserId: System myUserProfile userId) keysAndValuesDo: [:prjName :aLoadedProject |
+			(Rowan image  _loadedProjectRegistryForUserId: aUserId) keysAndValuesDo: [:prjName :aLoadedProject |
 				(self auditForProject: aLoadedProject) ifNotEmpty: [:aColl | res at: prjName put: aColl]
 	].
 	^res
-
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -1165,16 +1165,28 @@ RwPrjBrowserTool >> removeProtocol: hybridPackageName fromClassNamed: className 
 { #category : 'class browsing' }
 RwPrjBrowserTool >> renameClassNamed: className to: newName [
 
+	"
+		1. find references to the original class
+		2. copy class to renamed class
+		3. remove original class
+		4. change superclass for all subclasses of original class to renamed class
+
+		Worry about the fact that the references to the original class may be in methods will error out, if recompiled 
+	"
+
 	"anser the new copy of the class"
 
 	| projectSetDefinition loadedClass loadedPackage loadedProject projectDef packageDef |
+"1. find references to the original class"
 
+"2. copy class to renamed class"
 	projectSetDefinition := self _copyClassDefinitionNamed: className to: newName.
 
 	loadedClass := self 
 		_loadedClassNamed: className 
 		ifAbsent: [  self error: 'No loaded class named: ', className printString , ' found.' ].
 
+"3. remove original class definition"
 	loadedPackage := loadedClass loadedPackage.
 	loadedProject := loadedPackage loadedProject.
 	projectDef := projectSetDefinition projectNamed: loadedProject name ifAbsent: [ self error: 'No loaded project named: ', loadedProject printString , ' found.'].
@@ -1182,6 +1194,28 @@ RwPrjBrowserTool >> renameClassNamed: className to: newName [
 
 	packageDef removeClassNamed: className.
 
+"4. change superclass for all subclasses of original class to renamed class"
+	(Rowan globalNamed: className) subclasses do: [:subclass |
+		| subclassName classDef  |
+		subclassName := subclass name asString.
+		loadedClass := self 
+			_loadedClassNamed: subclassName
+			ifAbsent: [  self error: 'No loaded class named: ', subclassName printString , ' found.' ].
+
+		loadedPackage := loadedClass loadedPackage.
+		loadedProject := loadedPackage loadedProject.
+		projectDef := projectSetDefinition 
+			projectNamed: loadedProject name 
+			ifAbsent: [ 
+				| pDef |
+				pDef := loadedPackage loadedProject asDefinition.
+				projectSetDefinition addProject: pDef.
+				pDef ].
+		packageDef := projectDef packageNamed: loadedPackage name.
+		classDef := packageDef classDefinitions at: subclassName.
+		classDef superclassName: className ].
+
+"load projectSetDefinition & do rename"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 
 	^ Rowan globalNamed: newName

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -1165,19 +1165,20 @@ RwPrjBrowserTool >> removeProtocol: hybridPackageName fromClassNamed: className 
 { #category : 'class browsing' }
 RwPrjBrowserTool >> renameClassNamed: className to: newName [
 
-	"
-		1. find references to the original class
-		2. copy class to renamed class
-		3. remove original class
-		4. change superclass for all subclasses of original class to renamed class
+	"During renameClassNamed:to: a class is created with the new name and all methods 
+		are copied from the old class to the new class. If there are subclasses of the old class,
+		the subclasses are moved under the new class, then the old class is removed. It is
+		recommended that before renaming a class, you should find references to the class 
+		and be prepared to edit the methods once the rename is complete.
 
-		Worry about the fact that the references to the original class may be in methods will error out, if recompiled 
+	Worry about the fact that any references to the original class that may be in methods in 
+		the class itself or in subclass methods will error out, if recompiled 
 	"
 
 	"anser the new copy of the class"
 
 	| projectSetDefinition loadedClass loadedPackage loadedProject projectDef packageDef |
-"1. find references to the original class"
+"1. find references to the original class [not yet implemented]"
 
 "2. copy class to renamed class"
 	projectSetDefinition := self _copyClassDefinitionNamed: className to: newName.

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -1213,7 +1213,7 @@ RwPrjBrowserTool >> renameClassNamed: className to: newName [
 				pDef ].
 		packageDef := projectDef packageNamed: loadedPackage name.
 		classDef := packageDef classDefinitions at: subclassName.
-		classDef superclassName: className ].
+		classDef superclassName: newName ].
 
 "load projectSetDefinition & do rename"
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.

--- a/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjBrowserTool.class.st
@@ -5,6 +5,46 @@ Class {
 }
 
 { #category : 'private' }
+RwPrjBrowserTool >> _copyClassDefinitionNamed: className to: newName [
+
+	"answer a projectSetDefinition that includes the copied class definition"
+
+	| loadedClass classDef loadedPackage projectDef packageDef  projectSetDefinition |
+	(self _loadedClassNamed: newName ifAbsent:  [])
+		ifNotNil: [ self error: 'There is already a class named ', newName printString, ' in the system.' ].
+	loadedClass := self 
+		_loadedClassNamed: className 
+		ifAbsent: [  self error: 'No loaded class named: ', className printString , ' found.' ].
+	projectSetDefinition := RwProjectSetDefinition new.
+	loadedPackage := loadedClass loadedPackage.
+	projectDef := loadedPackage loadedProject asDefinition.
+	packageDef := projectDef packageNamed: loadedPackage name.
+	classDef := loadedClass asDefinition.
+	classDef name: newName.
+	packageDef addClassDefinition: classDef.
+	projectSetDefinition addProject: projectDef.
+
+	(self _loadedClassExtensionsNamed: className ifAbsent: [ #() ])
+		do: [:loadedClassExtension | 
+			| classExtDef loadedProject |
+			loadedPackage := loadedClassExtension loadedPackage.
+			loadedProject := loadedPackage loadedProject.
+			projectDef := projectSetDefinition
+				projectNamed: loadedPackage loadedProject name
+				ifAbsent: [ 
+					projectDef := loadedProject asDefinition.
+					projectSetDefinition addProject: projectDef.
+					projectDef ].
+
+			packageDef := projectDef packageNamed: loadedPackage name.
+			classExtDef := loadedClassExtension asDefinition.
+			classExtDef name: newName.
+			packageDef addClassExtension: classExtDef ].
+
+	^ projectSetDefinition
+]
+
+{ #category : 'private' }
 RwPrjBrowserTool >> _loadedClassExtensionsNamed: className [
 
 	^ self
@@ -700,44 +740,14 @@ RwPrjBrowserTool >> classNamed: className updateDefinition: updateBlock ifAbsent
 { #category : 'class browsing' }
 RwPrjBrowserTool >> copyClassNamed: className to: newName [
 
-	"we can make copy extensions optional if necessary"
+	"anser the new copy of the class"
 
-	| loadedClass classDef loadedPackage projectDef packageDef  projectSetDefinition |
-	(self _loadedClassNamed: newName ifAbsent:  [])
-		ifNotNil: [ self error: 'There is already a class named ', newName printString, ' in the system.' ].
-	loadedClass := self 
-		_loadedClassNamed: className 
-		ifAbsent: [  self error: 'No loaded class named: ', className printString , ' found.' ].
-	projectSetDefinition := RwProjectSetDefinition new.
-	loadedPackage := loadedClass loadedPackage.
-	projectDef := loadedPackage loadedProject asDefinition.
-	packageDef := projectDef packageNamed: loadedPackage name.
-	classDef := loadedClass asDefinition.
-	classDef name: newName.
-	packageDef addClassDefinition: classDef.
-	projectSetDefinition addProject: projectDef.
-
-	(self _loadedClassExtensionsNamed: className ifAbsent: [ #() ])
-		do: [:loadedClassExtension | 
-			| classExtDef loadedProject |
-			loadedPackage := loadedClassExtension loadedPackage.
-			loadedProject := loadedPackage loadedProject.
-			projectDef := projectSetDefinition
-				projectNamed: loadedPackage loadedProject name
-				ifAbsent: [ 
-					projectDef := loadedProject asDefinition.
-					projectSetDefinition addProject: projectDef.
-					projectDef ].
-
-			packageDef := projectDef packageNamed: loadedPackage name.
-			classExtDef := loadedClassExtension asDefinition.
-			classExtDef name: newName.
-			packageDef addClassExtension: classExtDef ].
+	| projectSetDefinition |
+	projectSetDefinition := self _copyClassDefinitionNamed: className to: newName.
 
 	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
 
 	^ Rowan globalNamed: newName
-
 ]
 
 { #category : 'class browsing' }
@@ -1155,12 +1165,26 @@ RwPrjBrowserTool >> removeProtocol: hybridPackageName fromClassNamed: className 
 { #category : 'class browsing' }
 RwPrjBrowserTool >> renameClassNamed: className to: newName [
 
-	| newClass |
+	"anser the new copy of the class"
 
-	newClass := self copyClassNamed: className to: newName.
-	self removeClassNamed: className.
-	^newClass
+	| projectSetDefinition loadedClass loadedPackage loadedProject projectDef packageDef |
 
+	projectSetDefinition := self _copyClassDefinitionNamed: className to: newName.
+
+	loadedClass := self 
+		_loadedClassNamed: className 
+		ifAbsent: [  self error: 'No loaded class named: ', className printString , ' found.' ].
+
+	loadedPackage := loadedClass loadedPackage.
+	loadedProject := loadedPackage loadedProject.
+	projectDef := projectSetDefinition projectNamed: loadedProject name ifAbsent: [ self error: 'No loaded project named: ', loadedProject printString , ' found.'].
+	packageDef := projectDef packageNamed: loadedPackage name.
+
+	packageDef removeClassNamed: className.
+
+	Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+	^ Rowan globalNamed: newName
 ]
 
 { #category : 'class browsing' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjLoadTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjLoadTool.class.st
@@ -108,14 +108,14 @@ RwPrjLoadTool >> _loadProjectSetDefinition_254: projectSetDefinitionToLoad insta
 				ifNil: [ projectDef specification ]
 				ifNotNil: [:loadedProject | loadedProject specification ].
 			self specification: theSpec.
-			theSpec updateLoadedCommitIdForTool: self.
+			projectDef projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue
+				ifTrue: [  theSpec updateLoadedCommitIdForTool: self ].
 			(loadedProjectInfo at: projectDef name ifAbsent: [])
 				ifNotNil: [:map |
 					theSpec imageSpec
 						loadedConfigurationNames: (map at: 'loadedConfigurationNames');
 						loadedGroupNames: (map at: 'loadedGroupNames') ] ].
 	^ diff
-
 ]
 
 { #category : 'private' }
@@ -141,14 +141,14 @@ RwPrjLoadTool >> _loadProjectSetDefinition: projectSetDefinitionToLoad instanceM
 	projectSetDefinitionToLoad definitions
 		do: [ :projectDef | 
 			self specification: projectDef specification.
-			projectDef specification updateLoadedCommitIdForTool: self.
+			projectDef projectDefinitionSourceProperty = RwLoadedProject _projectDiskDefinitionSourceValue
+				ifTrue: [ projectDef  updateLoadedCommitIdForTool: self ].
 			(loadedProjectInfo at: projectDef name ifAbsent: [])
 				ifNotNil: [:map |
 					projectDef specification imageSpec
 						loadedConfigurationNames: (map at: 'loadedConfigurationNames');
 						loadedGroupNames: (map at: 'loadedGroupNames') ]].
 	^ diff
-
 ]
 
 { #category : 'load project definitions' }

--- a/rowan/src/Rowan-Tools-Core/RwPrjReadTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwPrjReadTool.class.st
@@ -26,8 +26,8 @@ RwPrjReadTool >> _readProjectDefinition: projectDefinition packageNames: package
 				readPackageStructure.
 			packageDefinition := reader packageStructure rwSnapshot.
 			projectDefinition addOrUpdatePackage: packageDefinition ].
+	projectDefinition propertyAt: RwLoadedProject _projectDefinitionSourceKey put: RwLoadedProject _projectDiskDefinitionSourceValue.
 	^ projectDefinition
-
 ]
 
 { #category : 'private' }

--- a/test/specs/RowanSample4_295.ston
+++ b/test/specs/RowanSample4_295.ston
@@ -1,0 +1,11 @@
+ RwSimpleProjectSpecification{
+	#specName : 'RowanSample4_295',
+	#version : '0.2.0',
+	#projectUrl : 'https://github.com/dalehenrich/RowanSample4',
+	#configsPath : 'rowan/configs',
+	#repoPath : 'rowan/src',
+	#specsPath : 'rowan/specs',
+	#defaultConfigurationNames : [ 'Load' ],
+	#defaultGroupNames : [ 'tests' ],
+	#comment : 'Project used for Issue #295.'
+}


### PR DESCRIPTION
### New features
- Issue #447: "Need to give user control over initialization `policy`"
   - Automatic initialization black list:
   ```smalltalk
   "Add project to the default black list for all users - must be performed as SystemUser"
   Rowan platform automaticClassInitializationBlackList_default add: '<project-name>'.
   System commit.

   "Add project to the black list for the current user"
   Rowan platform automaticClassInitializationBlackList_user add: '<project-name>'.
   System commit.

   "Add project to the black list for the duration of the current session"
   Rowan automaticClassInitializationBlackList_session add: '<project-name>'.
   System commit.
   ```
   Automatic initialization will not be formed for any classes that are in a project listed in the black list.

- Issue #470: "`rename` class would be useful"
   - The following expression can be used to rename a class:
   ```smalltalk
   Rowan projectTools browser renameClassNamed: '<class-name>' to: '<new-name>'
   ```
   During `renameClassNamed:to:` a class is created with the new name and all methods are copied from the old class to the new class. If there are subclasses of the old class, the subclasses are moved under the new class, then the old class is removed. It is recommended that before renaming a class, you should find references to the class and be prepared to edit the methods once the rename is complete.

### Jadeite Version
[Oscar-3.0.65](https://github.com/GemTalk/Jadeite/releases/tag/Oscar-3.0.65)
### Script for v1.2.5 to v1.2.6 Update
```smalltalk
set u SystemUser p swordfish
login
run
| projectNames |
projectNames := #( 'STON' 'Cypress' 'Tonel'  'Rowan' ).
"audit before load"
projectNames do: [:projectName |
	| audit |
	"Pre load audit"
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Pre load Rowan audit failed for project ', projectName printString ]  ].
"Load projects"
projectNames do: [:projectName |
	"include tests and deprecated packages ... "
	Rowan projectTools load
		loadProjectNamed: projectName
		withGroupNames: #('tests' 'deprecated' 'jadeServer') ].
"Post load audit"
projectNames do: [:projectName |
	| audit |
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ].
System commit
%
```
### Bugfixes
- Issue #295: "Error creating a new class version while moving to a new package in a new project and a new symbol dictionary "
- Issue #389: "RwPkgAdopt>>adoptMethod:protocol:inClassNamed:isMeta:intoPackageNamed: unconditionally adopts the method AS AN EXTENSION METHOD'
- Issue #407: "Rowan install script should bail out early (with an error) if Rowan is already installed"
- Issue #427: "It should be possible to audit projects that are not installed by the current user..."
- Issue #428: "Need `existsOnDisk` message for RwProject ..."
- Issue #431: "`GsFile class existsOnServer:` can return `nil` on error ..."
- Issue #448: "RwPlatform settings (preferences) need to be able to set on global/user/session basis"
- Issue #450: "audit complains about `Class Extension is not present in the package` when an empty category is present"
- Issue #455: "`Class Extension` audit errors do not indicate whether the category is on the class-side or not"
- Issue #460: "Error creating a new class version with subclass method while moving to a new package in a new project and a new symbol dictionary"
- Issue #463: "project url api?"
- Issue #467: "new class version of class with subclasses in two different symbol dicts fails"
- Issue #469: "Looks like Rowan picks up the `loaded SHA` when an internal edit is made and not only when a load from disk is made"
