### PR TITLE
Fix for Jadeite issue 577 - login fails isSeparator

### DIFF
--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -323,7 +323,9 @@ RowanAnsweringService >> setEnableInteractionHandler: boolean [
 RowanAnsweringService >> sortedSymbols [
   answer := SortedCollection new.
   ((AllUsers userWithId: #'SymbolUser') resolveSymbol: #'AllSymbols') value
-    keysDo: [ :symbol | answer add: symbol ].
+    keysDo: [ :symbol | 
+      symbol charSize = 1
+        ifTrue: [ answer add: symbol ] ].
   answer := answer asArray.
   RowanCommandResult addResult: self
 ]


### PR DESCRIPTION
New post login code was caching symbols for autocomplete. 2 or 4 byte symbols were returning a DoubleByte or QuadByte string to STON. Now only get symbols whose charSize is 1.