### PR TITLE
v1.2.8 release

### DIFF
--- a/platforms/gemstone/bin/packing_oscar
+++ b/platforms/gemstone/bin/packing_oscar
@@ -36,6 +36,7 @@ set -e
 # 1.2.4 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.4 v1.2.4 Oscar-3.0.50
 # 1.2.5 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.5 v1.2.5 Oscar-3.0.50
 # 1.2.6 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.6 v1.2.6 Oscar-3.0.65
+# 1.2.7 $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/bin/packing_oscar Edelweiss-1.2.7 v1.2.7 Oscar-3.0.85
 #
 ANSI_RED="\033[91;1m"
 ANSI_GREEN="\033[92;1m"
@@ -118,7 +119,7 @@ clone_entire_git_repo() {
 
 cd $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/packing
 
-rm -rf Rowan MANIFEST.TXT Jadeite_runtime_* *.zip *.sha256
+rm -rf Rowan MANIFEST.TXT Jadeite_runtime_* *.zip *.sha256 *.pdf
 
 # Clone Rowan include all branches (complete copy of github repo)
 clone_entire_git_repo git@github.com:dalehenrich/Rowan.git Rowan $rowanDeploymentBranch
@@ -135,6 +136,9 @@ jadeite_runtime_dirName="Jadeite_runtime_${jadeite_tag}"
 wget https://github.com/GemTalk/Jadeite/releases/download/"$jadeite_tag"/runtime.zip
 unzip runtime.zip
 mv runtime "$jadeite_runtime_dirName"
+
+# copy documentation 
+cp /export/techpubs/JadeiteCurrent/*.pdf .
 
 echo "" >> MANIFEST.TXT
 echo "------------------------------" >> MANIFEST.TXT

--- a/platforms/gemstone/projects/cypress/src/Cypress-MesssageDigest/CypressMessageDigestStream.class.st
+++ b/platforms/gemstone/projects/cypress/src/Cypress-MesssageDigest/CypressMessageDigestStream.class.st
@@ -21,6 +21,23 @@ CypressMessageDigestStream class >> characters [
 
 ]
 
+{ #category : 'Documentation' }
+CypressMessageDigestStream class >> comment [
+"WriteStreamLegacy has a wired in comment method (in 2.3.15), so we
+	need this method to answer correctly provide the comment for this 
+	class"
+" As of GS/64 3.1, comments are now recorded in the class extraDict
+  dictionary under the key #comment.  Comment information formerly
+  recorded as a GsClassDocumentation under the key #description are
+  converted to a string and placed under #comment during DB 
+  conversion/upgrade. "
+
+  | cmt |
+  cmt := self _extraDictAt: #comment.
+  ^ cmt isNil ifTrue: [ '' ] ifFalse: [ cmt ]
+
+]
+
 { #category : 'digests' }
 CypressMessageDigestStream >> md5sum [
 

--- a/platforms/gemstone/topaz/3.2.15/cypress/Cypress-MesssageDigest.gs
+++ b/platforms/gemstone/topaz/3.2.15/cypress/Cypress-MesssageDigest.gs
@@ -74,6 +74,23 @@ characters
 	^self on: String new
 %
 
+category: 'Documentation'
+classmethod: CypressMessageDigestStream
+comment
+"WriteStreamLegacy has a wired in comment method (in 2.3.15), so we
+	need this method to answer correctly provide the comment for this 
+	class"
+" As of GS/64 3.1, comments are now recorded in the class extraDict
+  dictionary under the key #comment.  Comment information formerly
+  recorded as a GsClassDocumentation under the key #description are
+  converted to a string and placed under #comment during DB 
+  conversion/upgrade. "
+
+  | cmt |
+  cmt := self _extraDictAt: #comment.
+  ^ cmt isNil ifTrue: [ '' ] ifFalse: [ cmt ]
+%
+
 ! ------------------- Instance methods for CypressMessageDigestStream
 
 category: 'digests'

--- a/platforms/gemstone/topaz/3.2.15/installLegacyUnicode.tpz
+++ b/platforms/gemstone/topaz/3.2.15/installLegacyUnicode.tpz
@@ -1,0 +1,30 @@
+#
+# install Rowan into a default extent0.dbf: with Legacy Streams and Unicode comparison enabled
+#
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit 1
+
+  set u SystemUser p swordfish
+  login
+
+	run
+	Globals at: #StringConfiguration put: Unicode16.
+	System commit.
+%
+	logout	# to ensure Unicode comparison mode is enabled
+	errorCount
+	login
+
+	run
+	Stream installLegacyStreamImplementation.
+	System commit.
+	Unicode16 usingUnicodeCompares 
+		ifFalse: [ self error: 'Expected to be in Unicode comparison mode' ].
+	PositionableStream isLegacyStreamImplementation
+		ifFalse: [ self error: 'Expected to be using Legacy streams' ].
+%
+
+  logout
+  input  $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/install.tpz
+	errorCount

--- a/platforms/gemstone/topaz/3.2.15/installPortableString.tpz
+++ b/platforms/gemstone/topaz/3.2.15/installPortableString.tpz
@@ -1,0 +1,20 @@
+#
+# install Rowan into a default extent0.dbf: Portable Streams and Legacy String comparison 
+#
+  iferr 1 stk
+  iferr 2 stack
+  iferr 3 exit 1
+
+  set u SystemUser p swordfish
+  login
+
+	run
+	Unicode16 usingUnicodeCompares 
+		ifTrue: [ self error: 'Expected to be in Legacy String comparison mode' ].
+	PositionableStream isLegacyStreamImplementation
+		ifTrue: [ self error: 'Expected to be using Portable streams' ].
+%
+
+  logout
+  input  $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/install.tpz
+

--- a/platforms/gemstone/topaz/3.2.15/installRowanLegacyUnicode
+++ b/platforms/gemstone/topaz/3.2.15/installRowanLegacyUnicode
@@ -1,0 +1,19 @@
+#
+# install Rowan into a default extent0.dbf: with Legacy Streams and Unicode comparison enabled
+#
+
+set -e
+
+rm -rf *.out
+
+GEMSTONE_NAME=$1
+export ROWAN_HOME="$(dirname $0)/../../../../"
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/installLegacyUnicode.tpz
+
+  exit
+EOF
+

--- a/platforms/gemstone/topaz/3.2.15/installRowanPortableString
+++ b/platforms/gemstone/topaz/3.2.15/installRowanPortableString
@@ -1,0 +1,19 @@
+#
+# install Rowan into a default extent0.dbf: Portable Streams and Legacy String comparison 
+#
+
+set -e
+
+rm -rf *.out
+
+GEMSTONE_NAME=$1
+export ROWAN_HOME="$(dirname $0)/../../../../"
+
+startTopaz $GEMSTONE_NAME -l << EOF
+
+
+  input $ROWAN_PROJECTS_HOME/Rowan/platforms/gemstone/topaz/3.2.15/installPortableString.tpz
+
+  exit
+EOF
+

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -80,7 +80,9 @@ RowanAnsweringService >> autocompleteSymbols [
   SessionTemps current
     at: #'autocompleteSymbolCache'
     put: (Array with: newClassNames with: newLowerCaseSymbols).
-  answer := Array with: newClassNames with: newLowerCaseSymbols.
+  answer := Array
+    with: newClassNames asOrderedCollection
+    with: newLowerCaseSymbols asOrderedCollection.
   updateType := #'updateSymbols:'.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -17,9 +17,11 @@ Class {
 
 { #category : 'private' }
 RowanAnsweringService >> addLowerCaseSymbolsIn: theClass To: array [
-  array addAll: theClass selectors asArray.
-  array addAll: theClass class selectors asArray.
-  array addAll: theClass instVarNames asArray
+  array addAll: theClass selectors.
+  array addAll: theClass class selectors.
+  array addAll: theClass instVarNames.
+  array addAll: theClass class instVarNames.
+  array addAll: theClass classVarNames.
 ]
 
 { #category : 'client commands' }

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -61,6 +61,17 @@ RowanAnsweringService >> autoCommit [
 ]
 
 { #category : 'client commands' }
+RowanAnsweringService >> autocompleteSymbols [
+  answer := Dictionary new.
+  organizer classes
+    do: [ :cls | 
+      answer
+        at: cls name asString
+        put: cls selectors asArray , cls class selectors asArray ].
+  RowanCommandResult addResult: self
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> breakPointsAreEnabled [
   answer := RowanService breakPointsAreEnabled.
   updateType := #'breakpointSettingChanged:'.

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -15,6 +15,13 @@ Class {
 	#category : 'Rowan-Services-Core'
 }
 
+{ #category : 'private' }
+RowanAnsweringService >> addLowerCaseSymbolsIn: theClass To: array [
+  array addAll: theClass selectors asArray.
+  array addAll: theClass class selectors asArray.
+  array addAll: theClass instVarNames asArray
+]
+
 { #category : 'client commands' }
 RowanAnsweringService >> allClassesStartingWith: string [
   answer := SortedCollection new.
@@ -62,19 +69,19 @@ RowanAnsweringService >> autoCommit [
 
 { #category : 'client commands' }
 RowanAnsweringService >> autocompleteSymbols [
-  | newClassNames newSelectors |
+  | newClassNames newLowerCaseSymbols |
   newClassNames := Array new.
-  newSelectors := Array new.
+  newLowerCaseSymbols := Array new.
   organizer classes
     do: [ :cls | 
       newClassNames add: cls name asString.
-      newSelectors addAll: cls selectors asArray.
-      newSelectors addAll: cls class selectors asArray ].
-  newSelectors := newSelectors asSet asArray.
+      self addLowerCaseSymbolsIn: cls To: newLowerCaseSymbols ].
+  newLowerCaseSymbols := newLowerCaseSymbols asSet asArray.
   SessionTemps current
     at: #'autocompleteSymbolCache'
-    put: (Array with: newClassNames with: newSelectors).
-  answer := Array with: newClassNames with: newSelectors.
+    put: (Array with: newClassNames with: newLowerCaseSymbols).
+  answer := Array with: newClassNames with: newLowerCaseSymbols.
+  updateType := #'updateSymbols:'.
   RowanCommandResult addResult: self
 ]
 
@@ -397,27 +404,25 @@ RowanAnsweringService >> turnOffTranscriptWrites [
 
 { #category : 'client commands' }
 RowanAnsweringService >> updateAutocompleteSymbols [
-  | cache newClassNames newSelectors |
+  | cache newClassNames newLowerCaseSymbols |
   cache := SessionTemps current at: #'autocompleteSymbolCache'.
   newClassNames := Array new.
-  newSelectors := Array new.
+  newLowerCaseSymbols := Array new.
   organizer classes
     do: [ :cls | 
       (cache first includes: cls name asString)
         ifFalse: [ newClassNames add: cls name asString ].
-      newSelectors addAll: cls selectors.
-      newSelectors addAll: cls class selectors ].
-  newSelectors := newSelectors asSet asArray.
+      self addLowerCaseSymbolsIn: cls To: newLowerCaseSymbols ].
   (SessionTemps current at: #'autocompleteSymbolCache') first
     addAll: newClassNames.
-  newSelectors := newSelectors asSet asArray.
+  newLowerCaseSymbols := newLowerCaseSymbols asSet asArray.
   cache last
     do: [ :selector | 
-      (newSelectors includes: selector)
-        ifTrue: [ newSelectors remove: selector ] ].
+      (newLowerCaseSymbols includes: selector)
+        ifTrue: [ newLowerCaseSymbols remove: selector ] ].
   (SessionTemps current at: #'autocompleteSymbolCache') last
-    addAll: newSelectors.
-  answer := Array with: newClassNames with: newSelectors.
+    addAll: newLowerCaseSymbols.
+  answer := Array with: newClassNames with: newLowerCaseSymbols.
   updateType := #'updateSymbols:'.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -418,5 +418,6 @@ RowanAnsweringService >> updateAutocompleteSymbols [
   (SessionTemps current at: #'autocompleteSymbolCache') last
     addAll: newSelectors.
   answer := Array with: newClassNames with: newSelectors.
+  updateType := #'updateSymbols:'.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -409,7 +409,9 @@ RowanAnsweringService >> turnOffTranscriptWrites [
 { #category : 'client commands' }
 RowanAnsweringService >> updateAutocompleteSymbols [
   | cache newClassNames newLowerCaseSymbols |
-  cache := SessionTemps current at: #'autocompleteSymbolCache'.
+  cache := SessionTemps current
+    at: #'autocompleteSymbolCache'
+    ifAbsent: [ ^ self	"autocomplete not activated" ].
   newClassNames := Array new.
   newLowerCaseSymbols := Array new.
   organizer classes

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -63,7 +63,6 @@ RowanAnsweringService >> autoCommit [
 { #category : 'client commands' }
 RowanAnsweringService >> autocompleteSymbols [
   | newClassNames newSelectors |
-  answer := Dictionary new.
   newClassNames := Array new.
   newSelectors := Array new.
   organizer classes
@@ -72,9 +71,10 @@ RowanAnsweringService >> autocompleteSymbols [
       newSelectors addAll: cls selectors asArray.
       newSelectors addAll: cls class selectors asArray ].
   newSelectors := newSelectors asSet asArray.
-  SessionTemps
+  SessionTemps current
     at: #'autocompleteSymbolCache'
     put: (Array with: newClassNames with: newSelectors).
+  answer := Array with: newClassNames with: newSelectors.
   RowanCommandResult addResult: self
 ]
 
@@ -398,7 +398,7 @@ RowanAnsweringService >> turnOffTranscriptWrites [
 { #category : 'client commands' }
 RowanAnsweringService >> updateAutocompleteSymbols [
   | cache newClassNames newSelectors |
-  cache := SessionTemps at: #'autocompleteSymbolCache'.
+  cache := SessionTemps current at: #'autocompleteSymbolCache'.
   newClassNames := Array new.
   newSelectors := Array new.
   organizer classes
@@ -412,8 +412,10 @@ RowanAnsweringService >> updateAutocompleteSymbols [
         addAll:
           (cls class selectors reject: [ :selector | cache last includes: selector ]) ].
   newSelectors := newSelectors asSet asArray.
-  (SessionTemps at: #'autocompleteSymbolCache') first addAll: newClassNames.
-  (SessionTemps at: #'autocompleteSymbolCache') last addAll: newSelectors.
+  (SessionTemps current at: #'autocompleteSymbolCache') first
+    addAll: newClassNames.
+  (SessionTemps current at: #'autocompleteSymbolCache') last
+    addAll: newSelectors.
   answer := Array with: newClassNames with: newSelectors.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -405,15 +405,16 @@ RowanAnsweringService >> updateAutocompleteSymbols [
     do: [ :cls | 
       (cache first includes: cls name asString)
         ifFalse: [ newClassNames add: cls name asString ].
-      newSelectors
-        addAll:
-          (cls selectors reject: [ :selector | cache last includes: selector ]).
-      newSelectors
-        addAll:
-          (cls class selectors reject: [ :selector | cache last includes: selector ]) ].
+      newSelectors addAll: cls selectors.
+      newSelectors addAll: cls class selectors ].
   newSelectors := newSelectors asSet asArray.
   (SessionTemps current at: #'autocompleteSymbolCache') first
     addAll: newClassNames.
+  newSelectors := newSelectors asSet asArray.
+  cache last
+    do: [ :selector | 
+      (newSelectors includes: selector)
+        ifTrue: [ newSelectors remove: selector ] ].
   (SessionTemps current at: #'autocompleteSymbolCache') last
     addAll: newSelectors.
   answer := Array with: newClassNames with: newSelectors.

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -62,12 +62,19 @@ RowanAnsweringService >> autoCommit [
 
 { #category : 'client commands' }
 RowanAnsweringService >> autocompleteSymbols [
+  | newClassNames newSelectors |
   answer := Dictionary new.
+  newClassNames := Array new.
+  newSelectors := Array new.
   organizer classes
     do: [ :cls | 
-      answer
-        at: cls name asString
-        put: cls selectors asArray , cls class selectors asArray ].
+      newClassNames add: cls name asString.
+      newSelectors addAll: cls selectors asArray.
+      newSelectors addAll: cls class selectors asArray ].
+  newSelectors := newSelectors asSet asArray.
+  SessionTemps
+    at: #'autocompleteSymbolCache'
+    put: (Array with: newClassNames with: newSelectors).
   RowanCommandResult addResult: self
 ]
 
@@ -386,4 +393,27 @@ RowanAnsweringService >> turnOffTranscriptWrites [
 
 	self isTranscriptInstalled ifTrue:[
 		self flipTranscript]
+]
+
+{ #category : 'client commands' }
+RowanAnsweringService >> updateAutocompleteSymbols [
+  | cache newClassNames newSelectors |
+  cache := SessionTemps at: #'autocompleteSymbolCache'.
+  newClassNames := Array new.
+  newSelectors := Array new.
+  organizer classes
+    do: [ :cls | 
+      (cache first includes: cls name asString)
+        ifFalse: [ newClassNames add: cls name asString ].
+      newSelectors
+        addAll:
+          (cls selectors reject: [ :selector | cache last includes: selector ]).
+      newSelectors
+        addAll:
+          (cls class selectors reject: [ :selector | cache last includes: selector ]) ].
+  newSelectors := newSelectors asSet asArray.
+  (SessionTemps at: #'autocompleteSymbolCache') first addAll: newClassNames.
+  (SessionTemps at: #'autocompleteSymbolCache') last addAll: newSelectors.
+  answer := Array with: newClassNames with: newSelectors.
+  RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -13,7 +13,9 @@ Class {
 		'testPackages',
 		'testCount',
 		'dictionaries',
-		'selectedClass'
+		'selectedClass',
+		'newCachedSelectors',
+		'newCachedClasses'
 	],
 	#category : 'Rowan-Services-Core'
 }
@@ -145,6 +147,33 @@ RowanBrowserService >> findRemovedServices: services [
 	].
 ]
 
+{ #category : 'initialize' }
+RowanBrowserService >> initialize [
+  super initialize.
+  newCachedSelectors := Array new.
+  newCachedClasses := Array new
+]
+
+{ #category : 'accessing' }
+RowanBrowserService >> newCachedClasses [
+	^newCachedClasses
+]
+
+{ #category : 'accessing' }
+RowanBrowserService >> newCachedClasses: object [
+	newCachedClasses := object
+]
+
+{ #category : 'accessing' }
+RowanBrowserService >> newCachedSelectors [
+	^newCachedSelectors
+]
+
+{ #category : 'accessing' }
+RowanBrowserService >> newCachedSelectors: object [
+	newCachedSelectors := object
+]
+
 { #category : 'window registry' }
 RowanBrowserService >> openWindows [
 
@@ -205,6 +234,7 @@ RowanBrowserService >> recompileMethodsAfterClassCompilation [
   RowanCommandResult addResult: classService.
   selectedClass := classService.
   updateType := #'none'.
+  self updateSymbols: theClass name.
   RowanCommandResult addResult: self
 ]
 
@@ -326,4 +356,13 @@ RowanBrowserService >> updateProjects [
 	projects := sortedProjects collect:[:project | RowanProjectService newNamed: project name].
 	updateType := #projectsUpdate:browser:.
 	RowanCommandResult addResult: self
+]
+
+{ #category : 'update' }
+RowanBrowserService >> updateSymbols: className [
+  | browserService |
+  browserService := RowanBrowserService new.
+  browserService newCachedClasses add: className.
+  browserService updateType: #'addCachedSymbols:'.
+  RowanCommandResult addResult: browserService
 ]

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -31,6 +31,16 @@ RowanBrowserService >> abortTransaction [
 ]
 
 { #category : 'client commands' }
+RowanBrowserService >> abortTransactionAndUpdateServices: services [
+  self abortTransaction.
+  services
+    do: [ :service | 
+      service
+        organizer: organizer;
+        updateLatest ]
+]
+
+{ #category : 'client commands' }
 RowanBrowserService >> allClasses [
 	allClasses := self basicAllClasses.
 	updateType := #classes. "#classes not used at the moment so no updates will be done"

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -23,7 +23,9 @@ Class {
 { #category : 'client commands' }
 RowanBrowserService >> abortTransaction [
   | autoCommitService autoCommitState |
-  autoCommitState := RowanService autoCommit.
+  autoCommitState := RowanService autoCommit == #'failed'
+    ifTrue: [ true ]
+    ifFalse: [ RowanService autoCommit ].
   System abortTransaction.
   autoCommitService := RowanAutoCommitService new.
   autoCommitService autoCommit: autoCommitState.

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -35,9 +35,13 @@ RowanBrowserService >> abortTransactionAndUpdateServices: services [
   self abortTransaction.
   services
     do: [ :service | 
-      service
-        organizer: organizer;
-        updateLatest ]
+      "we just updated projects, package, & dictionary services"
+      (service isProjectService not
+        and: [ service isDictionaryService not and: [ service isPackageService not ] ])
+        ifTrue: [ 
+          service
+            organizer: organizer;
+            updateLatest ] ]
 ]
 
 { #category : 'client commands' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -26,9 +26,8 @@ RowanBrowserService >> abortTransaction [
   System abortTransaction.
   autoCommitService := RowanAutoCommitService new.
   autoCommitService autoCommit: true.
-  RowanBrowserService new updateProjects.
-  RowanBrowserService new updateDictionaries.
-  self updateType: #'aborted:browser:'
+  self updateProjects.
+  self updateDictionaries.
 ]
 
 { #category : 'client commands' }
@@ -363,7 +362,8 @@ RowanBrowserService >> updateDictionaries [
 
 	dictionaries := Rowan image symbolList names collect:[:name | RowanDictionaryService new name: name asString].
 	dictionaries := dictionaries asOrderedCollection. 
-	updateType := #dictionaryListUpdate:.
+	updateType ifNil: [updateType := OrderedCollection new]. 
+	updateType add: #dictionaryListUpdate:.
 	RowanCommandResult addResult: self
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -26,7 +26,6 @@ RowanBrowserService >> abortTransaction [
 	System abortTransaction.
 	self updateProjects.
 	self updateDictionaries. 
-	self packagesWithTests.
 	self updateType: #aborted:browser:.
 ]
 
@@ -349,13 +348,11 @@ RowanBrowserService >> unloadProjectsNamed: array [
       project := Rowan image loadedProjectNamed: projectName ifAbsent: [  ].
       project
         ifNotNil: [ Rowan projectTools delete deleteProjectNamed: projectName ] ].
-  self updateProjects.
-  self packagesWithTests
+  self updateProjects
 ]
 
 { #category : 'update' }
 RowanBrowserService >> update [
-
 	self updateProjects
 ]
 
@@ -370,12 +367,14 @@ RowanBrowserService >> updateDictionaries [
 
 { #category : 'client commands' }
 RowanBrowserService >> updateProjects [
-	| sortedProjects | 
-	sortedProjects := SortedCollection sortBlock: [:a :b | a name < b name]. 
-	sortedProjects addAll:  Rowan image loadedProjects.
-	projects := sortedProjects collect:[:project | RowanProjectService newNamed: project name].
-	updateType := #projectsUpdate:browser:.
-	RowanCommandResult addResult: self
+  | sortedProjects |
+  self packagesWithTests. "make sure tests are always updated" 
+  sortedProjects := SortedCollection sortBlock: [ :a :b | a name < b name ].
+  sortedProjects addAll: Rowan image loadedProjects.
+  projects := sortedProjects
+    collect: [ :project | RowanProjectService newNamed: project name ].
+  updateType := Array with: updateType with: #'projectsUpdate:browser:'. "temporary hack" 
+  RowanCommandResult addResult: self
 ]
 
 { #category : 'update' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -22,11 +22,13 @@ Class {
 
 { #category : 'client commands' }
 RowanBrowserService >> abortTransaction [
-
-	System abortTransaction.
-	self updateProjects.
-	self updateDictionaries. 
-	self updateType: #aborted:browser:.
+  | autoCommitService |
+  System abortTransaction.
+  autoCommitService := RowanAutoCommitService new.
+  autoCommitService autoCommit: true.
+  self updateProjects.
+  self updateDictionaries.
+  self updateType: #'aborted:browser:'
 ]
 
 { #category : 'client commands' }
@@ -247,7 +249,7 @@ RowanBrowserService >> recompileMethodsAfterClassCompilation [
   RowanCommandResult addResult: classService.
   selectedClass := classService.
   updateType := #'none'.
-  self updateSymbols: theClass name.
+  self updateSymbols: (Array with: theClass name).
   RowanCommandResult addResult: self
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -257,7 +257,7 @@ RowanBrowserService >> reloadProjects: projectServices andUpdateServices: servic
 		projectService reloadProject].
 	projectNames := projectServices collect: [:projectService | projectService name]. 
 	services do:[:service | 
-		(projectNames includes: service rowanProjectName) ifTrue:[service update]].
+		(projectNames includes: service rowanProjectName) ifTrue:[service updateLatest]].
 ]
 
 { #category : 'client commands' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -343,12 +343,14 @@ RowanBrowserService >> servicePerform: symbol withArguments: collection [
 
 { #category : 'client commands' }
 RowanBrowserService >> unloadProjectsNamed: array [
-	array do:[:projectName |
-		| project |
-		project := Rowan image loadedProjectNamed: projectName ifAbsent:[].
-		project ifNotNil: [
-			Rowan projectTools delete deleteProjectNamed: projectName]]. 
-	self updateProjects
+  array
+    do: [ :projectName | 
+      | project |
+      project := Rowan image loadedProjectNamed: projectName ifAbsent: [  ].
+      project
+        ifNotNil: [ Rowan projectTools delete deleteProjectNamed: projectName ] ].
+  self updateProjects.
+  self packagesWithTests
 ]
 
 { #category : 'update' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -251,13 +251,17 @@ RowanBrowserService >> releaseWindowHandle: integer [
 
 { #category : 'client commands' }
 RowanBrowserService >> reloadProjects: projectServices andUpdateServices: services [
-	| projectNames |
-	services do: [:service | service organizer: organizer]. 
-	projectServices do:[:projectService |
-		projectService reloadProject].
-	projectNames := projectServices collect: [:projectService | projectService name]. 
-	services do:[:service | 
-		(projectNames includes: service rowanProjectName) ifTrue:[service updateLatest]].
+  | projectNames answeringService |
+  services do: [ :service | service organizer: organizer ].
+  projectServices do: [ :projectService | projectService reloadProject ].
+  projectNames := projectServices
+    collect: [ :projectService | projectService name ].
+  services
+    do: [ :service | 
+      (projectNames includes: service rowanProjectName)
+        ifTrue: [ service updateLatest ] ].
+  answeringService := RowanAnsweringService new organizer: organizer.
+  answeringService updateAutocompleteSymbols
 ]
 
 { #category : 'client commands' }

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -26,8 +26,8 @@ RowanBrowserService >> abortTransaction [
   System abortTransaction.
   autoCommitService := RowanAutoCommitService new.
   autoCommitService autoCommit: true.
-  self updateProjects.
-  self updateDictionaries.
+  RowanBrowserService new updateProjects.
+  RowanBrowserService new updateDictionaries.
   self updateType: #'aborted:browser:'
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -22,12 +22,13 @@ Class {
 
 { #category : 'client commands' }
 RowanBrowserService >> abortTransaction [
-  | autoCommitService |
+  | autoCommitService autoCommitState |
+  autoCommitState := RowanService autoCommit.
   System abortTransaction.
   autoCommitService := RowanAutoCommitService new.
-  autoCommitService autoCommit: true.
+  autoCommitService autoCommit: autoCommitState.
   self updateProjects.
-  self updateDictionaries.
+  self updateDictionaries
 ]
 
 { #category : 'client commands' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -882,34 +882,41 @@ RowanClassService >> runMethodTests: methodServices [
 
 { #category : 'client commands' }
 RowanClassService >> saveMethodSource: source category: category [
-
-	| behavior compilationResult gsNMethod updatedCategory methodService |        
-	meta ifNil:[
-				behavior := (Object _objectForOop: oop). 
-				meta := behavior isMeta]
-			ifNotNil:[ 
-				behavior := meta ifTrue:[self theClass class] ifFalse:[self theClass]]. 
-	updatedCategory := category ifNil: ['other'].
-	compilationResult := self		
-		compileMethod: source 
-		behavior: behavior 
-		symbolList: Rowan image symbolList
-		inCategory: updatedCategory asSymbol.
-	(gsNMethod := compilationResult key) isNil ifTrue: [
-		System
-			signal: 1001  
-			args: (Array with: compilationResult value) 
-			signalDictionary: GemStoneError.
-	]. 
-	self update.  
-	methodService := self methodServiceFrom: gsNMethod in: behavior compiltationResult: compilationResult.
-	RowanCommandResult addResult: methodService.
-	RowanQueryService new 
-			organizer: ClassOrganizer new;
-			hierarchyImplementorsOf: methodService selector inClass: methodService className. "this will update hierarchy method indicators for client"
-	self selectedMethods: (Array with: methodService).
-	self updateDirtyState.
-	self updateTests.
+  | behavior compilationResult gsNMethod updatedCategory methodService |
+  meta
+    ifNil: [ 
+      behavior := Object _objectForOop: oop.
+      meta := behavior isMeta ]
+    ifNotNil: [ 
+      behavior := meta
+        ifTrue: [ self theClass class ]
+        ifFalse: [ self theClass ] ].
+  updatedCategory := category ifNil: [ 'other' ].
+  compilationResult := self
+    compileMethod: source
+    behavior: behavior
+    symbolList: Rowan image symbolList
+    inCategory: updatedCategory asSymbol.
+  (gsNMethod := compilationResult key) isNil
+    ifTrue: [ 
+      System
+        signal: 1001
+        args: (Array with: compilationResult value)
+        signalDictionary: GemStoneError ].
+  self update.
+  methodService := self
+    methodServiceFrom: gsNMethod
+    in: behavior
+    compiltationResult: compilationResult.
+  RowanCommandResult addResult: methodService.
+  RowanQueryService new
+    organizer: ClassOrganizer new;
+    hierarchyImplementorsOf: methodService selector
+      inClass: methodService className.	"this will update hierarchy method indicators for client"
+  self selectedMethods: (Array with: methodService).
+  self updateDirtyState.
+  self updateTests.
+  self updateSymbols: methodService selector
 ]
 
 { #category : 'other' }
@@ -1121,6 +1128,15 @@ RowanClassService >> updateSubclassesAfterRenameOf: newClass [
       | subclassService |
       subclassService := RowanClassService minimalForClassNamed: subclass name.
       RowanCommandResult addResult: subclassService ]
+]
+
+{ #category : 'updates' }
+RowanClassService >> updateSymbols: selector [
+  | browserService |
+  browserService := RowanBrowserService new.
+  browserService newCachedSelectors add: selector.
+  browserService updateType: #'addCachedSymbols:'.
+  RowanCommandResult addResult: browserService
 ]
 
 { #category : 'updates' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1067,6 +1067,7 @@ RowanClassService >> theClass [
 	theClass := oop ifNil:[Rowan globalNamed: name] ifNotNil: [Object _objectForOop: oop].
 	theClass isMeta ifTrue:[oop := theClass thisClass asOop]. 
 	(Rowan globalNamed: name) ifNil:[isInSymbolList := false]. 
+	theClass ifNil: [^nil]. 
 	^theClass thisClass
 ]
 
@@ -1102,8 +1103,12 @@ RowanClassService >> updateDirtyState [
 
 { #category : 'updates' }
 RowanClassService >> updateLatest [
-  oop := ((Rowan image symbolList resolveSymbol: name) ifNil: [ ^ self ]) value
-    asOop.
+  oop := ((Rowan image symbolList resolveSymbol: name)
+    ifNil: [ 
+      wasRemoved := true.
+      updateType := #'removedClass:'.
+      RowanCommandResult addResult: self.
+      ^ self ]) value asOop.
   super updateLatest
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -916,7 +916,7 @@ RowanClassService >> saveMethodSource: source category: category [
   self selectedMethods: (Array with: methodService).
   self updateDirtyState.
   self updateTests.
-  self updateSymbols: methodService selector
+  self updateSymbols: gsNMethod _selectorPool asArray , (Array with: methodService selector)
 ]
 
 { #category : 'other' }
@@ -1138,11 +1138,11 @@ RowanClassService >> updateSubclassesAfterRenameOf: newClass [
 ]
 
 { #category : 'updates' }
-RowanClassService >> updateSymbols: selector [
+RowanClassService >> updateSymbols: newSymbols [
   | browserService |
   browserService := RowanBrowserService new.
-  browserService newCachedSelectors add: selector.
-  browserService updateType: #'addCachedSymbols:'.
+  browserService newCachedSelectors addAll: newSymbols.
+  browserService updateType: #'addCachedSymbols:'. 
   RowanCommandResult addResult: browserService
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1102,7 +1102,8 @@ RowanClassService >> updateDirtyState [
 
 { #category : 'updates' }
 RowanClassService >> updateLatest [
-  oop := (Rowan image loadedClassNamed: name ifAbsent: [ ^ self ]) asOop.
+  oop := ((Rowan image symbolList resolveSymbol: name) ifNil: [ ^ self ]) value
+    asOop.
   super updateLatest
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1100,6 +1100,12 @@ RowanClassService >> updateDirtyState [
 	RowanCommandResult addResult: projectService.
 ]
 
+{ #category : 'updates' }
+RowanClassService >> updateLatest [
+  oop := (Rowan image loadedClassNamed: name ifAbsent: [ ^ self ]) asOop.
+  super updateLatest
+]
+
 { #category : 'private' }
 RowanClassService >> updateMethodsAfterRenameFrom: oldClassName to: newClassName [
   methods

--- a/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanCommandResult.class.st
@@ -15,6 +15,7 @@ RowanCommandResult class >> addResult: service [
 	service command: nil;
 			commandArgs: nil. 
 	self updateClientBoundServices: service.
+	^service
 ]
 
 { #category : 'accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanDictionaryService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanDictionaryService.class.st
@@ -48,6 +48,11 @@ RowanDictionaryService >> insertAt: index [
 	RowanBrowserService new updateDictionaries.
 ]
 
+{ #category : 'testing' }
+RowanDictionaryService >> isDictionaryService [
+  ^ true
+]
+
 { #category : 'accessing' }
 RowanDictionaryService >> name [
 	^name

--- a/rowan/src/Rowan-Services-Core/RowanLoggingService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanLoggingService.class.st
@@ -53,7 +53,7 @@ RowanLoggingService >> logComment: string [
 	time := Time now.
 	location := #server.
 	stonString := STON toString: self.
-	ws := FileStream 
+	ws := FileStreamPortable 
 				write: fileName
 				mode: #append.
 	[ws nextPutAll: stonString] ensure: [ws close].
@@ -64,7 +64,7 @@ RowanLoggingService >> logComment: string [
 RowanLoggingService >> logFileContents [
 
 	| rs |
-	rs := [FileStream read: fileName] on: Error do:[:ex | ^String new].
+	rs := [FileStreamPortable read: fileName] on: Error do:[:ex | ^String new].
 	[^rs contents] ensure: [rs close]
 ]
 
@@ -95,7 +95,7 @@ RowanLoggingService >> logServices [
 	time := Time now.
 	location := #server.
 	stonString := STON toString: self.
-	ws := FileStream 
+	ws := FileStreamPortable 
 				write: fileName
 				mode: #append.
 	[ws nextPutAll: stonString] ensure: [ws close]

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -282,7 +282,7 @@ RowanMethodService >> debugTest: testSelector inClassName: theClassName [
           (ex class isSubclassOf: Notification)
             ifTrue: [ 'passed' ]
             ifFalse: [ 'error' ] ].
-      ex signal ].
+      ex pass ].
   testRunClassName := theClassName.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -706,6 +706,17 @@ RowanMethodService >> update [
 	RowanCommandResult addResult: self.
 ]
 
+{ #category : 'updates' }
+RowanMethodService >> updateLatest [
+  | theClass compiledMethod |
+  theClass := (RowanClassService new name: className) theClass.
+  theClass ifNil: [ ^ self ].
+  compiledMethod := theClass compiledMethodAt: selector otherwise: nil.
+  compiledMethod ifNil: [ ^ self ].
+  oop := compiledMethod asOop.
+  super updateLatest
+]
+
 { #category : 'private' }
 RowanMethodService >> updateSource: string [
 

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -371,6 +371,8 @@ RowanProjectService >> reloadProject [
         cr;
         show: ex description.
       ex resume ].
+  self update.
+  RowanCommandResult addResult: self.
   RowanBrowserService new packagesWithTests
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3084
+  ^ 3085
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -497,6 +497,14 @@ RowanService >> updateInternalService: updatedService [
 	"no internally held services to update"
 ]
 
+{ #category : 'update' }
+RowanService >> updateLatest [
+  "subclasses may want to special behavior to update themselves
+	to their loaded version"
+
+  self update
+]
+
 { #category : 'accessing' }
 RowanService >> updateType: aSymbol [
 

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -280,6 +280,12 @@ RowanService >> isClassService [
 ]
 
 { #category : 'testing' }
+RowanService >> isDictionaryService [
+
+	^false
+]
+
+{ #category : 'testing' }
 RowanService >> isMethodService [
 
 	^false

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3085
+  ^ 3086
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3086
+  ^ 3087
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3083
+  ^ 3084
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -237,7 +237,7 @@ RowanService >> extendHierarchies: hierarchies [
 
 { #category : 'perform' }
 RowanService >> handleDeletedService [
-  updateType := #'removed:'.
+  self updateType: #'removed:'.
   RowanCommandResult addResult: self
 ]
 

--- a/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanMethodServiceTest.class.st
@@ -20,11 +20,11 @@ RowanMethodServiceTest >> stepPoint1Source [
 
 	| array |
 	array := Array new. 
-						"^1"
+			"^3"		"^2"
 	array add: OrderedCollection new. 
-			"^3"							"^2"
+			"^5"							"^4"
 	array size.
-			"^4"
+			"^6"
 	^array'
 ]
 
@@ -115,15 +115,6 @@ RowanMethodServiceTest >> test_isTestMethod [
 ]
 
 { #category : 'tests' }
-RowanMethodServiceTest >> test_noStepPoints [
-	| classService methodService |
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
-	classService saveMethodSource: 'abc' category: 'testing step points'.
-	methodService := RowanMethodService forSelector: #abc class: classService classOrMeta meta: false organizer: ClassOrganizer new.
-	self assert: methodService stepPoints isEmpty.
-]
-
-{ #category : 'tests' }
 RowanMethodServiceTest >> test_reformatSource [
 	| classService methodService source |
 		classService := RowanClassService forClassNamed: self servicesDefaultClassName.
@@ -157,59 +148,4 @@ RowanMethodServiceTest >> test_runMethodTest [
 	classService saveMethodSource: 'testMethod2  1 zork' category: 'failing test'.
 	methodService runTest: #testMethod2 inClassName: self servicesDefaultTestClassName.
 	self assert: methodService testResult equals: 'error'.
-]
-
-{ #category : 'tests' }
-RowanMethodServiceTest >> test_stepPoint1 [
-	| classService methodService |
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
-	classService saveMethodSource: self stepPoint1Source category: 'testing step points'.
-	methodService := RowanMethodService forSelector: #simpleMethod class: classService classOrMeta meta: false organizer: ClassOrganizer new.
-	self assert: methodService stepPoints size equals: 4.		
-	self assert: (methodService source copyFrom: 42 to: 44) asSymbol equals: (methodService stepPoints at: 1) value. "#new"
-	self assert: (methodService source copyFrom: 89 to: 91) asSymbol equals: (methodService stepPoints at: 2) value. "#new"
-	self assert: (methodService source copyFrom: 66 to: 69) asSymbol equals: (methodService stepPoints at: 3) value. "#add:"
-	self assert: (methodService source copyFrom: 121 to: 124) asSymbol equals: (methodService stepPoints at: 4) value. "#size"
-]
-
-{ #category : 'tests' }
-RowanMethodServiceTest >> test_stepPoint2 [
-	| classService methodService |
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
-	classService saveMethodSource: self stepPoint2Source category: 'testing step points'.
-	methodService := RowanMethodService forSelector: #simpleMethod2 class: classService classOrMeta meta: false organizer: ClassOrganizer new.
-	self assert: methodService stepPoints size equals: 7.		
-	self assert: (methodService source copyFrom: 43 to: 45) asSymbol equals: (methodService stepPoints at: 1) value. "#new"
-	self assert: (methodService source copyFrom: 91 to: 104) asSymbol equals: (methodService stepPoints at: 2) value. "#forClassNamed:"
-	self assert: (methodService source copyFrom: 67 to: 70) asSymbol equals: (methodService stepPoints at: 3) value. "#add:"
-	self assert: (methodService source copyFrom: 145 to: 147) asSymbol equals: (methodService stepPoints at: 4) value. "#do:"
-	self assert: (methodService source copyFrom: 295 to: 298) asSymbol equals: (methodService stepPoints at: 5) value. "#size"
-	self assert: (methodService source copyFrom: 225 to: 234) asSymbol equals: (methodService stepPoints at: 6) value. "#stepPoints"
-	self assert: (methodService source copyFrom: 268 to: 271) asSymbol equals: (methodService stepPoints at: 7) value. "#size"
-]
-
-{ #category : 'tests' }
-RowanMethodServiceTest >> test_stepPoint3 [
-	| classService methodService |
-	classService := RowanClassService forClassNamed: self servicesDefaultClassName.
-	classService saveMethodSource: self stepPoint3Source category: 'testing step points'.
-	methodService := RowanMethodService forSelector: #'initialize:status:' class: classService classOrMeta meta: false organizer: ClassOrganizer new.
-	self assert: methodService stepPoints size equals: 9.		
-	self assert: (methodService source copyFrom: 109 to: 111) asSymbol equals: (methodService stepPoints at: 1) value. 
-	self assert: (methodService stepPoints at: 1) value equals: #new.
-	self assert: (methodService source copyFrom: 165 to: 174) asSymbol equals: (methodService stepPoints at: 2) value.
-	self assert: (methodService stepPoints at: 2) value equals: #stackDepth.
-	self assert: (methodService source copyFrom: 149 to: 152) asSymbol equals: (methodService stepPoints at: 3) value. 
-	self assert: (methodService stepPoints at: 3) value equals: #new:.
-	self assert: (methodService source copyFrom: 216 to: 225) asSymbol equals: (methodService stepPoints at: 4) value. 
-	self assert: (methodService stepPoints at: 4) value equals: #stackDepth.
-	self assert: (methodService source copyFrom: 290 to: 297) asSymbol equals: #process:. 
-	self assert: (methodService stepPoints at: 5) value equals: #'process:level:organizer:'. 
-	self assert: (methodService source copyFrom: 260 to: 262) asSymbol equals: #at:. 		
-	self assert: (methodService stepPoints at: 6) value equals: #at:put:.
-
-	"7 & 8 are present in 3.2.15 but are incorrect presumably due to optimization. Later server versions may get this fixed"
-	
-	self assert: (methodService source copyFrom: 392 to: 396) asSymbol equals: (methodService stepPoints at: 9) value. "#asOop"
-self assert: (methodService stepPoints at: 9) value equals: #asOop.
 ]

--- a/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
@@ -48,7 +48,7 @@ RowanPackageServiceTest >> test_compileAndSelectClass [
 		options: #()'.
   self assert: RowanCommandResult results size equals: 0.	"we no longer return a service on first stage of compile"
   browserService recompileMethodsAfterClassCompilation.
-  self assert: RowanCommandResult results size equals: 5.
+  self assert: RowanCommandResult results size equals: 6.
   self
     assert: (RowanCommandResult results at: 4) name
     equals: 'RowanTestCompile'.

--- a/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
@@ -77,7 +77,7 @@ RowanPackageServiceTest >> test_compileAndSelectClassDifferentPackage [
 		options: #()'.
   self assert: RowanCommandResult results size equals: 0.	"we no longer return a service on first stage of compile"
   browserService recompileMethodsAfterClassCompilation.
-  self assert: RowanCommandResult results size equals: 5.
+  self assert: RowanCommandResult results size equals: 6.
   self
     assert: (RowanCommandResult results at: 4) name
     equals: 'RowanTestCompile'.

--- a/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanQueryServicesTest.class.st
@@ -5,6 +5,23 @@ Class {
 }
 
 { #category : 'tests' }
+RowanQueryServicesTest >> test_dontUseFileStream [
+  | queryService results |
+  self
+    jadeiteIssueTested: #'issue611'
+    withTitle: 'Use FileStreamPortable not FileStream'.
+  queryService := RowanQueryService new.
+  queryService organizer: ClassOrganizer new.
+  queryService browseClassReferences: 'FileStream'.
+  results := queryService queryResults.
+  self assert: results size equals: 1.
+  self assert: results first className equals: 'Stream'.
+  self
+    assert: results first selector
+    equals: #'installStreamImplementationFrom:'
+]
+
+{ #category : 'tests' }
 RowanQueryServicesTest >> test_hierarchyImplementors [
 
 	| queryService hierarchyClassNames |


### PR DESCRIPTION
This is a Jadeite release with performance improvements.
### Jadeite Version
[Oscar-3.0.87](https://github.com/GemTalk/Jadeite/releases/tag/Oscar-3.0.87)

Jadeite fixes described in the `Jadeite-ReleaseNotes-3.0.87`
### Script for v1.2.7 to v1.2.8 Update
```smalltalk
set u SystemUser p swordfish
login
run
| projectNames |
projectNames := #( 'Rowan' 'STON' 'Cypress' 'Tonel' ).
"audit before load"
projectNames do: [:projectName |
	| audit |
	"Pre load audit"
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Pre load Rowan audit failed for project ', projectName printString ]  ].
"Load projects"
projectNames do: [:projectName |
	"include tests and deprecated packages ... "
	Rowan projectTools load
		loadProjectNamed: projectName
		withGroupNames: #('tests' 'deprecated' 'jadeServer') ].
"Post load audit"
projectNames do: [:projectName |
	| audit |
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ].
System commit
%
```
### Rowan Bugfixes
Issue #526: "Need to test with both Legacy Stream and Portable Stream images .... "

