### PR TITLE
v1.2.9 release

### DIFF
--- a/rowan/src/Rowan-GemStone-Core/RwGsLoadedSymbolDictMethod.class.st
+++ b/rowan/src/Rowan-GemStone-Core/RwGsLoadedSymbolDictMethod.class.st
@@ -40,6 +40,17 @@ RwGsLoadedSymbolDictMethod >> key [
 	^ name	"This is inadequate because the same selector can be defined in both class and metaclass?"
 ]
 
+{ #category : 'printing' }
+RwGsLoadedSymbolDictMethod >> printOn: aStream [
+
+	super printOn: aStream.
+	name
+		ifNotNil: 
+			[aStream
+				space;
+				nextPutAll: handle inClass printString, ' ( ', handle inClass asOop asString, ' )' ]
+]
+
 { #category : 'accessing' }
 RwGsLoadedSymbolDictMethod >> source [
 

--- a/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanAnsweringService.class.st
@@ -325,6 +325,27 @@ RowanAnsweringService >> printStringOf: oop toMaxSize: integer [
 ]
 
 { #category : 'client commands' }
+RowanAnsweringService >> profile: block [
+  "not used yet. Utility method needs testing.
+	Make sure block execution time is long enough - say 1 second. 
+	Results may not be consistent
+
+	Usage example: 
+| block answeringService | 
+block := [| browserService profMonitor |
+		browserService := (RowanBrowserService new) .
+		10 timesRepeat:[browserService packagesWithTests]]. 
+answeringService := RowanAnsweringService new profile: block.
+answeringService answer. "
+
+  | time ns |
+  time := System millisecondsToRun: block.
+  ns := ProfMonitor computeInterval: time / 1000.
+  answer := ProfMonitor monitorBlock: block intervalNs: ns.
+  RowanCommandResult addResult: self
+]
+
+{ #category : 'client commands' }
 RowanAnsweringService >> runMethodTests: methodServices [
 
 	| behavior |

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -208,15 +208,25 @@ RowanBrowserService >> packagesWithTests [
   (organizer allSubclassesOf: TestCase)
     do: [ :sub | 
       | packageName |
-      testCount := testCount + sub testSelectors size.
+      testCount := testCount
+        + (sub sunitSelectors select: [ :each | each beginsWith: 'test' ]) size.	"sending #testSelectors was slower"
       packageName := sub rowanPackageName.
       packageName = Rowan unpackagedName
-        ifFalse: [ testPackages add: (RowanPackageService forPackageNamed: packageName) ].
+        ifFalse: [ 
+          testPackages
+            add:
+              (RowanPackageService new
+                name: packageName;
+                updateProjectName;
+                yourself) ].
       (Rowan image loadedClassExtensionsForClass: sub)
         do: [ :loadedThing | 
           testPackages
             add:
-              (RowanPackageService forPackageNamed: loadedThing loadedPackage name) ] ].
+              (RowanPackageService new
+                name: loadedThing loadedPackage name;
+                updateProjectName;
+                yourself)	"don't update the entire package for performance improvement" ] ].
   updateType := #'testPackages:'.
   testPackages := testPackages asArray.
   RowanCommandResult addResult: self

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -203,26 +203,15 @@ RowanBrowserService >> openWindows [
 RowanBrowserService >> packagesWithTests [
   testPackages := Set new.
   testCount := 0.
-  TestCase allSubclasses
-    do: [ :testSubclass | 
-      | suite |
-      suite := testSubclass buildSuite.
-      suite tests
-        do: [ :testCase | 
-          | packageName compiledMethod |
-          (testCase isKindOf: TestSuite)
-            ifFalse: [ 
-              compiledMethod := testCase class
-                compiledMethodAt: testCase selector
-                otherwise: nil.
-              packageName := compiledMethod
-                ifNil: [ testCase class rowanPackageName ]
-                ifNotNil: [ compiledMethod rowanPackageName ].
-              packageName = Rowan unpackagedName
-                ifFalse: [ 
-                  testCount := testCount + 1.
-                  testPackages
-                    add: (RowanPackageService forPackageNamed: packageName) ] ] ] ].
+  testPackages := Set new.
+  testCount := 0.
+  (organizer allSubclassesOf: TestCase) 
+    do: [ :sub | 
+      | packageName |
+      testCount := testCount + sub testSelectors size.
+      packageName := sub rowanPackageName.
+      packageName = Rowan unpackagedName
+        ifFalse: [ testPackages add: (RowanPackageService forPackageNamed: packageName) ] ].
   updateType := #'testPackages:'.
   testPackages := testPackages asArray.
   RowanCommandResult addResult: self

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -201,32 +201,36 @@ RowanBrowserService >> openWindows [
 
 { #category : 'client commands' }
 RowanBrowserService >> packagesWithTests [
+  organizer := ClassOrganizer new.	"when we call this method, our world has changed from a reload, etc."
   testPackages := Set new.
   testCount := 0.
   testPackages := Set new.
   testCount := 0.
   (organizer allSubclassesOf: TestCase)
     do: [ :sub | 
-      | packageName |
-      testCount := testCount
-        + (sub sunitSelectors select: [ :each | each beginsWith: 'test' ]) size.	"sending #testSelectors was slower"
-      packageName := sub rowanPackageName.
-      packageName = Rowan unpackagedName
-        ifFalse: [ 
-          testPackages
-            add:
-              (RowanPackageService new
-                name: packageName;
-                updateProjectName;
-                yourself) ].
-      (Rowan image loadedClassExtensionsForClass: sub)
-        do: [ :loadedThing | 
-          testPackages
-            add:
-              (RowanPackageService new
-                name: loadedThing loadedPackage name;
-                updateProjectName;
-                yourself)	"don't update the entire package for performance improvement" ] ].
+      | packageName testMethodCount |
+      testMethodCount := (sub sunitSelectors
+        select: [ :each | each beginsWith: 'test' ]) size.	"sending #testSelectors was slower"
+      testCount := testCount + testMethodCount.
+      testMethodCount > 0
+        ifTrue: [ 
+          packageName := sub rowanPackageName.
+          packageName = Rowan unpackagedName
+            ifFalse: [ 
+              testPackages
+                add:
+                  (RowanPackageService new
+                    name: packageName;
+                    updateProjectName;
+                    yourself) ].
+          (Rowan image loadedClassExtensionsForClass: sub)
+            do: [ :loadedThing | 
+              testPackages
+                add:
+                  (RowanPackageService new
+                    name: loadedThing loadedPackage name;
+                    updateProjectName;
+                    yourself)	"don't update the entire package for performance improvement" ] ] ].
   updateType := #'testPackages:'.
   testPackages := testPackages asArray.
   RowanCommandResult addResult: self

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -259,6 +259,7 @@ RowanBrowserService >> releaseWindowHandle: integer [
 RowanBrowserService >> reloadProjects: projectServices andUpdateServices: services [
   | projectNames answeringService |
   services do: [ :service | service organizer: organizer ].
+  projectServices do: [ :service | service organizer: organizer ].
   projectServices do: [ :projectService | projectService reloadProject ].
   projectNames := projectServices
     collect: [ :projectService | projectService name ].

--- a/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanBrowserService.class.st
@@ -205,13 +205,18 @@ RowanBrowserService >> packagesWithTests [
   testCount := 0.
   testPackages := Set new.
   testCount := 0.
-  (organizer allSubclassesOf: TestCase) 
+  (organizer allSubclassesOf: TestCase)
     do: [ :sub | 
       | packageName |
       testCount := testCount + sub testSelectors size.
       packageName := sub rowanPackageName.
       packageName = Rowan unpackagedName
-        ifFalse: [ testPackages add: (RowanPackageService forPackageNamed: packageName) ] ].
+        ifFalse: [ testPackages add: (RowanPackageService forPackageNamed: packageName) ].
+      (Rowan image loadedClassExtensionsForClass: sub)
+        do: [ :loadedThing | 
+          testPackages
+            add:
+              (RowanPackageService forPackageNamed: loadedThing loadedPackage name) ] ].
   updateType := #'testPackages:'.
   testPackages := testPackages asArray.
   RowanCommandResult addResult: self

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1067,6 +1067,7 @@ RowanClassService >> theClass [
 	theClass := oop ifNil:[Rowan globalNamed: name] ifNotNil: [Object _objectForOop: oop].
 	theClass isMeta ifTrue:[oop := theClass thisClass asOop]. 
 	(Rowan globalNamed: name) ifNil:[isInSymbolList := false]. 
+	theClass ifNil: [^nil]. 
 	^theClass thisClass
 ]
 
@@ -1102,8 +1103,12 @@ RowanClassService >> updateDirtyState [
 
 { #category : 'updates' }
 RowanClassService >> updateLatest [
-  oop := ((Rowan image symbolList resolveSymbol: name) ifNil: [ ^ self ]) value
-    asOop.
+  oop := ((Rowan image symbolList resolveSymbol: name)
+    ifNil: [ 
+      wasRemoved := true.
+      updateType := #'removedClass:'.
+      RowanCommandResult addResult: self.
+      ^ self ]) value asOop.
   super updateLatest
 ]
 

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1155,9 +1155,12 @@ RowanClassService >> updateSymbols: newSymbols [
 RowanClassService >> updateTests [
   "update the test browsers on certain operations"
 
-  RowanBrowserService new packagesWithTests.
-  (RowanPackageService new name: packageName) testClasses.
-  RowanCommandResult addResult: self update.
+  (RowanBrowserService new organizer: organizer) packagesWithTests.
+  (RowanPackageService new
+    organizer: organizer;
+    name: packageName;
+    yourself) testClasses.
+  RowanCommandResult addResult: self update
 ]
 
 { #category : 'Accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1155,7 +1155,7 @@ RowanClassService >> updateSymbols: newSymbols [
 RowanClassService >> updateTests [
   "update the test browsers on certain operations"
 
-  (RowanBrowserService new organizer: organizer) packagesWithTests.
+  RowanBrowserService new packagesWithTests.
   (RowanPackageService new
     organizer: organizer;
     name: packageName;

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -1157,7 +1157,6 @@ RowanClassService >> updateTests [
 
   RowanBrowserService new packagesWithTests.
   (RowanPackageService new
-    organizer: organizer;
     name: packageName;
     yourself) testClasses.
   RowanCommandResult addResult: self update

--- a/rowan/src/Rowan-Services-Core/RowanClassService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanClassService.class.st
@@ -109,6 +109,13 @@ RowanClassService >> addSubclassWarningString [
 	^'Superclass is not packaged. Enter the desired package name'
 ]
 
+{ #category : 'client commands' }
+RowanClassService >> allSubclassServices [
+  hierarchyServices := self classHierarchy: (Array with: self theClass).
+  (hierarchyServices at: self ifAbsent:[^self])
+    do: [ :classService | classService allSubclassServices ]
+]
+
 { #category : 'Accessing' }
 RowanClassService >> allTests [
 	| allSelectors theClass |
@@ -413,6 +420,23 @@ RowanClassService >> forClassNamed: className [
 	self refreshFrom: theClass.
 ]
 
+{ #category : 'client commands' }
+RowanClassService >> fullHierarchy [
+  | behavior sortedSubclasses |
+  behavior := self theClass.
+  hierarchyServices := Dictionary new.
+  hierarchyServices at: #'expand' put: Array new.
+  sortedSubclasses := behavior subclasses
+    asSortedCollection: [ :x :y | x name < y name ].
+  RowanCommandResult addResult: self.
+  sortedSubclasses
+    do: [ :subclass | 
+      | classService |
+      classService := (self classServiceFromOop: subclass asOop) meta: meta.
+      (hierarchyServices at: #'expand') add: classService.
+      classService allSubclassServices ]
+]
+
 { #category : 'comparing' }
 RowanClassService >> hash [
 	^self name hash bitXor: meta hash
@@ -620,17 +644,20 @@ RowanClassService >> objectInBaseNamed: aString [
 
 { #category : 'client commands' }
 RowanClassService >> oneLevelClassHierarchy [
-	"good for expanding an existing hierarchy quickly"
-	| behavior sortedSubclasses |
-	behavior := self theClass. 
-	hierarchyServices := Dictionary new. 
-	hierarchyServices at: #expand put: Array new. 
-	sortedSubclasses := behavior subclasses asSortedCollection:[:x :y | x name < y name].
-	sortedSubclasses do: [:subclass |
-		| classService |
-		classService := (self classServiceFromOop: subclass asOop) meta: meta.
-		(hierarchyServices at: #expand) add: classService. 
-	].
+  "good for expanding an existing hierarchy quickly"
+
+  | behavior sortedSubclasses |
+  behavior := self theClass.
+  hierarchyServices := Dictionary new.
+  hierarchyServices at: #'expand' put: Array new.
+  sortedSubclasses := behavior subclasses
+    asSortedCollection: [ :x :y | x name < y name ].
+  sortedSubclasses
+    do: [ :subclass | 
+      | classService |
+      classService := (self classServiceFromOop: subclass asOop) meta: meta.
+      (hierarchyServices at: #'expand') add: classService ].
+  RowanCommandResult addResult: self
 ]
 
 { #category : 'Accessing' }

--- a/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanMethodService.class.st
@@ -282,7 +282,7 @@ RowanMethodService >> debugTest: testSelector inClassName: theClassName [
           (ex class isSubclassOf: Notification)
             ifTrue: [ 'passed' ]
             ifFalse: [ 'error' ] ].
-      ex signal ].
+      ex pass ].
   testRunClassName := theClassName.
   RowanCommandResult addResult: self
 ]

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -311,6 +311,7 @@ RowanPackageService >> setDefaultTemplate [
 
 { #category : 'client commands' }
 RowanPackageService >> testClasses [
+  organizer := ClassOrganizer new.
   testClasses := Set new.
   self loadedClasses
     valuesDo: [ :loadedClass | 

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -242,12 +242,12 @@ RowanPackageService >> projectName: newValue [
 
 { #category : 'client commands' }
 RowanPackageService >> removeClass: classService [
-	self removeClassNamed: classService name. 
-	self setDefaultTemplate.
-	classService updateType: #removedClass:.
-	classService wasRemoved: true. 
-	RowanCommandResult addResult: classService.
-	(RowanBrowserService new organizer: organizer) packagesWithTests. "sunit browser might need updated"
+  self removeClassNamed: classService name.
+  self setDefaultTemplate.
+  classService updateType: #'removedClass:'.
+  classService wasRemoved: true.
+  RowanCommandResult addResult: classService.
+  RowanBrowserService new packagesWithTests	"sunit browser might need updated"
 ]
 
 { #category : 'commands support' }

--- a/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanPackageService.class.st
@@ -247,7 +247,7 @@ RowanPackageService >> removeClass: classService [
 	classService updateType: #removedClass:.
 	classService wasRemoved: true. 
 	RowanCommandResult addResult: classService.
-	RowanBrowserService new packagesWithTests. "sunit browser might need updated"
+	(RowanBrowserService new organizer: organizer) packagesWithTests. "sunit browser might need updated"
 ]
 
 { #category : 'commands support' }
@@ -311,31 +311,29 @@ RowanPackageService >> setDefaultTemplate [
 
 { #category : 'client commands' }
 RowanPackageService >> testClasses [
-  organizer := ClassOrganizer new.
   testClasses := Set new.
-  TestCase allSubclasses
-    do: [ :testSubclass | 
-      testSubclass isAbstract
-        ifFalse: [ 
-          testSubclass suite tests
-            do: [ :testClassInstance | 
-              | implementingClass compiledMethod |
-              compiledMethod := testSubclass
-                compiledMethodAt: testClassInstance selector
-                otherwise: nil.
-              compiledMethod
-                ifNil: [ 
-                  implementingClass := testClassInstance class
-                    whichClassIncludesSelector: testClassInstance selector.
-                  compiledMethod := implementingClass
-                    compiledMethodAt: testClassInstance selector ].
-              (compiledMethod rowanPackageName = name
-                or: [ testSubclass rowanPackageName = name ])
-                ifTrue: [ 
-                  | classService |
-                  classService := RowanClassService
-                    basicForClassNamed: testSubclass name.
-                  testClasses add: classService ] ] ] ].
+  self loadedClasses
+    valuesDo: [ :loadedClass | 
+      | cls |
+      cls := loadedClass handle.
+      (cls inheritsFrom: TestCase)
+        ifTrue: [ 
+          cls isAbstract
+            ifFalse: [ 
+              | classService |
+              classService := RowanClassService basicForClassNamed: cls name.
+              testClasses add: classService ] ] ].
+  self loadedClassExtensions
+    valuesDo: [ :loadedClass | 
+      | cls |
+      cls := loadedClass handle.
+      (cls inheritsFrom: TestCase)
+        ifTrue: [ 
+          cls isAbstract
+            ifFalse: [ 
+              | classService |
+              classService := RowanClassService basicForClassNamed: cls name.
+              testClasses add: classService ] ] ].
   updateType := #'testClasses:'.
   testClasses := testClasses asArray.
   RowanCommandResult addResult: self

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -246,7 +246,7 @@ RowanProjectService >> newGitProject: url root: rootPath useSsh: useSsh [
 		cloneSpecUrl: url
 		gitRootPath: rootPath
 		useSsh: useSsh.
-	RowanBrowserService new updateProjects.
+	(RowanBrowserService new organizer: organizer) updateProjects.
 ]
 
 { #category : 'rowan' }
@@ -373,7 +373,7 @@ RowanProjectService >> reloadProject [
       ex resume ].
   self update.
   RowanCommandResult addResult: self.
-  RowanBrowserService new packagesWithTests
+  (RowanBrowserService new organizer: organizer) packagesWithTests
 ]
 
 { #category : 'rowan' }

--- a/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanProjectService.class.st
@@ -373,7 +373,7 @@ RowanProjectService >> reloadProject [
       ex resume ].
   self update.
   RowanCommandResult addResult: self.
-  (RowanBrowserService new organizer: organizer) packagesWithTests
+  RowanBrowserService new packagesWithTests
 ]
 
 { #category : 'rowan' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3085
+  ^ 3086
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3086
+  ^ 3087
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Core/RowanService.class.st
+++ b/rowan/src/Rowan-Services-Core/RowanService.class.st
@@ -83,7 +83,7 @@ RowanService class >> version [
   "change this method carefully and only at Jadeite release boundaries.
 	Failure to do so will prevent logins"
 
-  ^ 3087
+  ^ 3088
 ]
 
 { #category : 'other' }

--- a/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanPackageServiceTest.class.st
@@ -77,7 +77,7 @@ RowanPackageServiceTest >> test_compileAndSelectClassDifferentPackage [
 		options: #()'.
   self assert: RowanCommandResult results size equals: 0.	"we no longer return a service on first stage of compile"
   browserService recompileMethodsAfterClassCompilation.
-  self assert: RowanCommandResult results size equals: 5.
+  self assert: RowanCommandResult results size equals: 6.
   self
     assert: (RowanCommandResult results at: 4) name
     equals: 'RowanTestCompile'.

--- a/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
+++ b/rowan/src/Rowan-Services-Tests/RowanServicesTest.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : 'Rowan-Services-Tests'
 }
 
+{ #category : 'testing' }
+RowanServicesTest class >> isAbstract [
+  ^ self sunitName = #'RowanServicesTest'
+]
+
 { #category : 'unicode method' }
 RowanServicesTest >> addUnicodeSymbolKeyToUserGlobals [
   "RowanServicesTest new addUnicodeSymbolKeyToUserGlobals"

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -4289,3 +4289,182 @@ RwBrowserToolApiTest >> testRenameClass_5 [
 "validate"
    validateBlock value: class1 value: class2 value: class3.
 ]
+
+{ #category : 'tests' }
+RwBrowserToolApiTest >> testRenameClass_Issue_490 [
+
+  "rename a class with no subclasses"
+
+  "https://github.com/dalehenrich/Rowan/issues/490"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition 
+		packageDefinition className1 className2 className3 className4 projectSetDefinition
+		class1 class2 class3 oldClass1 oldClass2 oldClass3 classExtensionDefinition audit symDict 
+		registry extraMethods methodRegistry seenMethodsMap |
+
+  projectName := 'Issue470'.
+  packageName1 := 'Issue470-Core'.
+  packageName2 := 'Issue470-Extensions'.
+  className1 := 'Issue470Class1'.
+  className2 := 'Issue470Class2'.
+  className3 := 'Issue470Class3'.
+  className4 := 'Issue470Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^3' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+  class1 := Rowan globalNamed: className1.
+  class2 := Rowan globalNamed: className2.
+  class3 := Rowan globalNamed: className3.
+
+"perform rename"
+  Rowan projectTools browser
+    renameClassNamed: className2 to: className4.
+
+  self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty.
+
+"validate"
+  oldClass1 := class1.
+  oldClass2 := class2.
+  oldClass3 := class3.
+ 
+  class1 := Rowan globalNamed: className1.
+  self assert: oldClass1 == class1.
+
+  class2 := Rowan globalNamed: className4.
+  self assert: class2 superClass == class1.
+  self assert: oldClass2 ~~ class2. "renamed class"
+
+  class3 := Rowan globalNamed: className3.
+  self assert: class3 superClass == class2.
+  self assert: oldClass3 ~~ class3. "new version, since superclass renamed"
+
+"audit"
+  symDict := Rowan globalNamed: self _symbolDictionaryName1.
+  self assert: (symDict at: className4 asSymbol) == class2.
+  registry := symDict at: #RwSymbolDictionaryRegistry.
+  methodRegistry := registry methodRegistry.
+  seenMethodsMap := Dictionary new.
+  methodRegistry keysAndValuesDo: [:method :loadedMethod |
+    ((seenMethodsMap at: method inClass name ifAbsentPut: [ Dictionary new])
+		at: method selector ifAbsentPut: [ {} ]) add: method ].
+  extraMethods := Dictionary new.
+  seenMethodsMap keysAndValuesDo: [:className :selectorMap |
+    selectorMap keysAndValuesDo: [:selector :ar |
+      ar size > 1 
+        ifTrue: [
+          (extraMethods at: className ifAbsentPut: [ Dictionary new ])
+            at: selector put: ar ] ] ].
+  false ifTrue: [ self assert: extraMethods size = 0 ].
+ "repair"
+  extraMethods keysAndValuesDo: [:className :selectorMap |
+    selectorMap keysAndValuesDo: [:selector :ar |
+      ar do: [:method |
+        | theClass x|
+        theClass := method inClass.
+         theClass :=theClass isMeta
+           ifTrue: [ (Rowan globalNamed: theClass theNonMetaClass name) class ]
+           ifFalse: [ Rowan globalNamed: theClass name ].
+        (x := theClass compiledMethodAt: selector) == method
+          ifFalse: [ methodRegistry removeKey: method ] ] ] ].
+
+  seenMethodsMap := Dictionary new.
+  methodRegistry keysAndValuesDo: [:method :loadedMethod |
+    ((seenMethodsMap at: method inClass name ifAbsentPut: [ Dictionary new])
+		at: method selector ifAbsentPut: [ {} ]) add: method ].
+  extraMethods := Dictionary new.
+  seenMethodsMap keysAndValuesDo: [:className :selectorMap |
+    selectorMap keysAndValuesDo: [:selector :ar |
+      ar size > 1 
+        ifTrue: [
+          (extraMethods at: className ifAbsentPut: [ Dictionary new ])
+            at: selector put: ar ] ] ].
+  true ifTrue: [ self assert: extraMethods size = 0 ].
+self halt.
+]

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -4466,5 +4466,4 @@ RwBrowserToolApiTest >> testRenameClass_Issue_490 [
           (extraMethods at: className ifAbsentPut: [ Dictionary new ])
             at: selector put: ar ] ] ].
   true ifTrue: [ self assert: extraMethods size = 0 ].
-self halt.
 ]

--- a/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
+++ b/rowan/src/Rowan-Tests/RwBrowserToolApiTest.class.st
@@ -4441,8 +4441,8 @@ RwBrowserToolApiTest >> testRenameClass_Issue_490 [
         ifTrue: [
           (extraMethods at: className ifAbsentPut: [ Dictionary new ])
             at: selector put: ar ] ] ].
-  false ifTrue: [ self assert: extraMethods size = 0 ].
- "repair"
+  true ifTrue: [ self assert: extraMethods size = 0 ].
+ false ifTrue: [ "repair"
   extraMethods keysAndValuesDo: [:className :selectorMap |
     selectorMap keysAndValuesDo: [:selector :ar |
       ar do: [:method |
@@ -4465,5 +4465,5 @@ RwBrowserToolApiTest >> testRenameClass_Issue_490 [
         ifTrue: [
           (extraMethods at: className ifAbsentPut: [ Dictionary new ])
             at: selector put: ar ] ] ].
-  true ifTrue: [ self assert: extraMethods size = 0 ].
+  true ifTrue: [ self assert: extraMethods size = 0 ] ].
 ]

--- a/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
@@ -283,7 +283,9 @@ RwProjectAuditToolTest >> test_Issue_534 [
     renameClassNamed: className2 to: className4.
 
 "Until Issue #490 is fixed, the audit is expected to fail ..."
-  self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty not.
+  audit := Rowan projectTools audit auditForProjectNamed: projectName.
+  self assert: (audit at: packageName1 ifAbsent: []) isNil.
+   self assert: ((audit at: packageName2) at: className3) size = 1.
 ]
 
 { #category : 'tests' }
@@ -513,7 +515,7 @@ RwProjectAuditToolTest >> testClassVars [
 	self assert: testClassB == (Rowan globalNamed: className) description: 'Rowan does not resolve new version of class'.
 	self deny: testClassB == testClass.
 	self assert: (x := Rowan projectTools audit auditForProjectNamed:  'AuditProject') size = 1.
-	self assert: ((x at: packageName) at: className) size = 4 description: 'expected 4 failures superclass instvars classvars and comment'
+	self assert: ((x at: packageName) at: className) size = 5 description: 'expected 5 failures superclass instvars classvars comment and loaded class not latest'
 
 ]
 

--- a/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
+++ b/rowan/src/Rowan-Tests/RwProjectAuditToolTest.class.st
@@ -169,6 +169,124 @@ RwProjectAuditToolTest >> _auditLoadedClassExtensionBlock [
 ]
 
 { #category : 'tests' }
+RwProjectAuditToolTest >> test_Issue_534 [
+
+  "https://github.com/dalehenrich/Rowan/issues/534"
+
+  | projectName  packageName1 packageName2 projectDefinition classDefinition1 classDefinition 
+		packageDefinition className1 className2 className3 className4 projectSetDefinition
+		class1 class2 class3  classExtensionDefinition audit |
+
+  projectName := 'Issue534'.
+  packageName1 := 'Issue534-Core'.
+  packageName2 := 'Issue534-Extensions'.
+  className1 := 'Issue534Class1'.
+  className2 := 'Issue534Class2'.
+  className3 := 'Issue534Class3'.
+  className4 := 'Issue534Class4'.
+
+  {projectName}
+    do: [ :pn |
+      (Rowan image loadedProjectNamed: pn ifAbsent: [  ])
+        ifNotNil: [ :loadedProject | Rowan image _removeLoadedProject: loadedProject ] ].
+
+"create project"
+  projectDefinition := (RwProjectDefinition
+    newForGitBasedProjectNamed: projectName)
+    addPackageNamed: packageName1;
+    addPackageNamed: packageName2;
+    defaultSymbolDictName: self _symbolDictionaryName1;
+    yourself.
+
+  packageDefinition := projectDefinition packageNamed: packageName1.
+
+  classDefinition1 := (RwClassDefinition
+    newForClassNamed: className1
+      super: 'Object'
+      instvars: #(ivar1)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod1 ^1' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod1 ^', className2 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition1.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className2
+      super: className1
+      instvars: #(ivar2)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod2 ^2' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod2 ^', className3 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+  classDefinition := (RwClassDefinition
+    newForClassNamed: className3
+      super: className2
+      instvars: #(ivar4 ivar3)
+      classinstvars: #()
+      classvars: #()
+      category: packageName1
+      comment: 'comment'
+      pools: #()
+      type: 'normal')
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'instanceMethod3 ^3' protocol: 'accessing');
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'classMethod3 ^', className1 protocol: 'accessing');
+    yourself.
+  packageDefinition
+    addClassDefinition: classDefinition.
+
+"create extension methods"
+  packageDefinition := projectDefinition packageNamed: packageName2.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className1)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod1 ^1' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod1 ^1' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className2)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod2 ^2' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod2 ^2' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+  classExtensionDefinition := (RwClassExtensionDefinition newForClassNamed: className3)
+    addInstanceMethodDefinition: (RwMethodDefinition newForSource: 'extensionInstanceMethod3 ^3' protocol: '*', packageName2 asLowercase);
+    addClassMethodDefinition: (RwMethodDefinition newForSource: 'extensionClassMethod3 ^3' protocol: '*', packageName2 asLowercase); 
+    yourself.
+  packageDefinition addClassExtension: classExtensionDefinition.
+
+"load"
+  projectSetDefinition := RwProjectSetDefinition new.
+  projectSetDefinition addDefinition: projectDefinition.
+  Rowan projectTools load loadProjectSetDefinition: projectSetDefinition.
+
+  class1 := Rowan globalNamed: className1.
+  class2 := Rowan globalNamed: className2.
+  class3 := Rowan globalNamed: className3.
+
+"perform rename"
+  Rowan projectTools browser
+    renameClassNamed: className2 to: className4.
+
+"Until Issue #490 is fixed, the audit is expected to fail ..."
+  self assert: (audit := Rowan projectTools audit auditForProjectNamed: projectName) isEmpty not.
+]
+
+{ #category : 'tests' }
 RwProjectAuditToolTest >> test_issue478 [
 
 	"https://github.com/GemTalk/Rowan/issues/478"

--- a/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsAuditTool.class.st
@@ -172,6 +172,18 @@ RwClsAuditTool >> auditLoadedClass: aLoadedClass [
 	(Rowan globalNamed: aLoadedClass name)  
 		ifNil: [self errorLog: res add: aLoadedClass name -> 'Missing gemstone class for loaded class ' ] "there is no matching Class for LoadedClass"
 		ifNotNil: [:aBehavior | 
+
+			aBehavior == aLoadedClass handle
+				ifFalse: [ 
+					self
+						errorLog: res
+						add:
+							aLoadedClass name
+								->
+									('loaded class (' , aLoadedClass handle asOop printString
+									, ') not latest version of class ('
+									, aBehavior asOop printString , ') ') ].
+
 			"audit class properties"
 			self errorLog: res addAll:  (self _auditLoadedClassProperties: aLoadedClass forBehavior: aBehavior).
 			"audit categories"

--- a/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
@@ -39,7 +39,7 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 							add:
 								(aLoadedClassExtension name , ' #' , extensionCategoryName)
 									->
-										('extension class (' , aLoadedClassExtension handle asOop printString
+										(' loaded extension class (' , aLoadedClassExtension handle asOop printString
 										, ') not latest version of class ('
 										, aBehavior asOop printString , ') ') ].
 

--- a/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
+++ b/rowan/src/Rowan-Tools-Core/RwClsExtensionAuditTool.class.st
@@ -32,6 +32,17 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 		ifNil: [self errorLog: res  add: aLoadedClassExtension name -> ' Class does not exists for loaded class '] 
 		ifNotNil: [:aBehavior ||categories | 
 					
+				aBehavior == aLoadedClassExtension handle
+					ifFalse: [ 
+						self
+							errorLog: res
+							add:
+								(aLoadedClassExtension name , ' #' , extensionCategoryName)
+									->
+										('extension class (' , aLoadedClassExtension handle asOop printString
+										, ') not latest version of class ('
+										, aBehavior asOop printString , ') ') ].
+
 				categories := (aBehavior _baseCategorys: 0) keys.
 				(categories	
 					detect: [:each | each equalsNoCase: extensionCategoryName ] ifNone: [ ])
@@ -59,5 +70,4 @@ RwClsExtensionAuditTool >> auditLoadedClassExtension: aLoadedClassExtension [
 				]
 		].
 		^res
-
 ]


### PR DESCRIPTION
This is a Jadeite release with performance improvements.
### Jadeite Version
[Oscar-3.0.89](https://github.com/GemTalk/Jadeite/releases/tag/Oscar-3.0.89)

Jadeite fixes described in the `Jadeite-ReleaseNotes-3.0.89`
### Script for v1.2.8 to v1.2.9 Update
```smalltalk
set u SystemUser p swordfish
login
run
| projectNames |
projectNames := #( 'Rowan' 'STON' 'Cypress' 'Tonel' ).
"audit before load"
projectNames do: [:projectName |
	| audit |
	"Pre load audit"
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Pre load Rowan audit failed for project ', projectName printString ]  ].
"Load projects"
projectNames do: [:projectName |
	"include tests and deprecated packages ... "
	Rowan projectTools load
		loadProjectNamed: projectName
		withGroupNames: #('tests' 'deprecated' 'jadeServer') ].
"Post load audit"
projectNames do: [:projectName |
	| audit |
	audit := Rowan projectTools audit auditForProjectNamed: projectName.
	audit isEmpty ifFalse: [ self error: 'Post load Rowan audit failed for project ', projectName printString ] ].
System commit
%
```
### Rowan Bugfixes
Issue #534: "project audit does not detect the corruption introduced by issue #535"

